### PR TITLE
Windows: per-app capture startup + callback safety fixes

### DIFF
--- a/native/src/addon.cpp
+++ b/native/src/addon.cpp
@@ -12,6 +12,7 @@
 #include <napi.h>
 #include "audio_capture.h"
 #include <memory>
+#include <cstring>
 
 static std::unique_ptr<haven::IAudioCapture> g_capture;
 
@@ -99,15 +100,25 @@ static Napi::Value StartCapture(const Napi::CallbackInfo& info) {
     }
 
     haven::AudioDataCb nativeCb = [](const float* data, size_t count) {
+        if (!data || count == 0) {
+            return;
+        }
+
         float* copy = new float[count];
         std::memcpy(copy, data, count * sizeof(float));
 
-        g_tsfn.NonBlockingCall(copy, [count](Napi::Env env, Napi::Function fn, float* buf) {
-            Napi::ArrayBuffer ab = Napi::ArrayBuffer::New(env, buf, count * sizeof(float),
-                [](Napi::Env, void* ptr) { delete[] static_cast<float*>(ptr); });
+        napi_status status = g_tsfn.NonBlockingCall(copy, [count](Napi::Env env, Napi::Function fn, float* buf) {
+            // Use JS-owned backing memory to avoid external buffer lifetime issues.
+            Napi::ArrayBuffer ab = Napi::ArrayBuffer::New(env, count * sizeof(float));
+            std::memcpy(ab.Data(), buf, count * sizeof(float));
+            delete[] buf;
             Napi::Float32Array f32 = Napi::Float32Array::New(env, count, ab, 0);
             fn.Call({ f32 });
         });
+
+        if (status != napi_ok) {
+            delete[] copy;
+        }
     };
 
     haven::CaptureStatusCb nativeStatusCb;

--- a/native/src/win/wasapi_capture.cpp
+++ b/native/src/win/wasapi_capture.cpp
@@ -36,6 +36,7 @@
 #include <string>
 #include <cstring>
 #include <algorithm>
+#include <chrono>
 
 #pragma comment(lib, "ole32.lib")
 #pragma comment(lib, "mmdevapi.lib")
@@ -72,12 +73,16 @@ static std::string ProcessNameFromPid(DWORD pid) {
 }
 
 // ── Completion handler for ActivateAudioInterfaceAsync ────
-class ActivateHandler : public IActivateAudioInterfaceCompletionHandler {
+class ActivateHandler : public IActivateAudioInterfaceCompletionHandler, public IAgileObject {
 public:
-    ActivateHandler() : m_refCount(1), m_hr(E_FAIL), m_client(nullptr) {
+    ActivateHandler() : m_refCount(1), m_hr(E_FAIL), m_client(nullptr), m_ftm(nullptr) {
         m_event = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+        CoCreateFreeThreadedMarshaler(static_cast<IUnknown*>(static_cast<IActivateAudioInterfaceCompletionHandler*>(this)), &m_ftm);
     }
-    ~ActivateHandler() { CloseHandle(m_event); }
+    ~ActivateHandler() {
+        if (m_ftm) m_ftm->Release();
+        CloseHandle(m_event);
+    }
 
     // IUnknown
     ULONG STDMETHODCALLTYPE AddRef()  override { return InterlockedIncrement(&m_refCount); }
@@ -91,6 +96,14 @@ public:
             *ppv = static_cast<IActivateAudioInterfaceCompletionHandler*>(this);
             AddRef();
             return S_OK;
+        }
+        if (riid == __uuidof(IAgileObject)) {
+            *ppv = static_cast<IAgileObject*>(this);
+            AddRef();
+            return S_OK;
+        }
+        if (riid == __uuidof(IMarshal) && m_ftm) {
+            return m_ftm->QueryInterface(riid, ppv);
         }
         *ppv = nullptr;
         return E_NOINTERFACE;
@@ -123,6 +136,7 @@ private:
     ULONG         m_refCount;
     HRESULT       m_hr;
     IAudioClient* m_client;
+    IUnknown*     m_ftm;
     HANDLE        m_event;
 };
 
@@ -282,7 +296,12 @@ bool WasapiCapture::StartCapture(uint32_t pid, CaptureMode mode,
         m_mode           = mode;
         m_callback       = dataCb;
         m_statusCallback = statusCb;
-        m_initOk         = false;
+    }
+
+    {
+        std::lock_guard<std::mutex> startLock(m_startMutex);
+        m_startState = StartupState::Starting;
+        m_startHr = E_PENDING;
     }
 
     // Pre-flight: verify PID is valid and accessible.
@@ -298,13 +317,6 @@ bool WasapiCapture::StartCapture(uint32_t pid, CaptureMode mode,
         CloseHandle(h);
     }
 
-    if (m_initEvent) { CloseHandle(m_initEvent); m_initEvent = nullptr; }
-    m_initEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-    if (!m_initEvent) {
-        emitStatus(CaptureStatusKind::Failed, "CreateEvent failed", GetLastError());
-        return false;
-    }
-
     emitStatus(CaptureStatusKind::Starting,
         std::string("activating ") +
         (mode == CaptureMode::ExcludeProcess ? "EXCLUDE-mode" : "INCLUDE-mode") +
@@ -313,18 +325,19 @@ bool WasapiCapture::StartCapture(uint32_t pid, CaptureMode mode,
     m_running = true;
     m_thread = std::thread([this]() { captureLoop(); });
 
-    // Wait up to 4 seconds for the thread to signal init complete.
-    DWORD waitResult = WaitForSingleObject(m_initEvent, 4000);
-    if (waitResult != WAIT_OBJECT_0 || !m_initOk.load()) {
-        // Init didn't complete in time, or completed with failure.
-        // The capture thread may still be retrying — stop it cleanly.
-        if (waitResult != WAIT_OBJECT_0) {
+    std::unique_lock<std::mutex> startLock(m_startMutex);
+    bool signaled = m_startCv.wait_for(startLock, std::chrono::milliseconds(12000), [this]() {
+        return m_startState != StartupState::Starting;
+    });
+
+    if (!signaled || m_startState == StartupState::Failed) {
+        if (!signaled) {
             emitStatus(CaptureStatusKind::Failed,
-                "WASAPI activation timed out (>4s)", 0);
+                "WASAPI activation timed out (>12s)", 0);
         }
         m_running = false;
+        startLock.unlock();
         if (m_thread.joinable()) m_thread.join();
-        CloseHandle(m_initEvent); m_initEvent = nullptr;
         return false;
     }
 
@@ -339,7 +352,11 @@ void WasapiCapture::StopCapture() {
         std::lock_guard<std::mutex> lock(m_mutex);
         m_callback = nullptr;
     }
-    if (m_initEvent) { CloseHandle(m_initEvent); m_initEvent = nullptr; }
+    {
+        std::lock_guard<std::mutex> startLock(m_startMutex);
+        m_startState = StartupState::Idle;
+        m_startHr = S_OK;
+    }
     if (wasRunning) {
         emitStatus(CaptureStatusKind::Stopped, "capture stopped");
     }
@@ -352,14 +369,20 @@ void WasapiCapture::StopCapture() {
 void WasapiCapture::Cleanup() { StopCapture(); }
 
 // ── Capture Loop ───────────────────────────────────────────
-// Activation runs on this thread, but we signal m_initEvent as
-// soon as init succeeds OR hard-fails so StartCapture can return
-// synchronously with an accurate result. After init: just the
-// read loop runs here.
+// Activation runs on this thread. We signal startup state via
+// m_startCv as soon as init succeeds OR hard-fails so StartCapture
+// can return synchronously with an accurate result. After init:
+// just the read loop runs here.
 void WasapiCapture::captureLoop() {
-    auto signalInit = [&](bool ok) {
-        m_initOk = ok;
-        if (m_initEvent) SetEvent((HANDLE)m_initEvent);
+    auto failStart = [this](HRESULT hr, const std::string& msg) {
+        emitStatus(CaptureStatusKind::Failed, msg, hr);
+        {
+            std::lock_guard<std::mutex> startLock(m_startMutex);
+            m_startState = StartupState::Failed;
+            m_startHr = hr;
+        }
+        m_startCv.notify_all();
+        m_running = false;
     };
 
     CoInitializeEx(nullptr, COINIT_MULTITHREADED);
@@ -391,13 +414,10 @@ void WasapiCapture::captureLoop() {
     );
 
     if (FAILED(hr)) {
-        emitStatus(CaptureStatusKind::Failed,
-            "ActivateAudioInterfaceAsync returned failure (process loopback API may be unavailable)",
-            hr);
+        failStart(hr,
+            "ActivateAudioInterfaceAsync returned failure (process loopback API may be unavailable)");
         handler->Release();
         CoUninitialize();
-        m_running = false;
-        signalInit(false);
         return;
     }
 
@@ -407,14 +427,11 @@ void WasapiCapture::captureLoop() {
     handler->Release();
 
     if (FAILED(hr) || !client) {
-        emitStatus(CaptureStatusKind::Failed,
+        failStart(FAILED(hr) ? hr : E_FAIL,
             (hr == E_ACCESSDENIED)
                 ? "Process loopback denied (target may be a protected/UWP process)"
-                : "ActivateCompleted reported failure",
-            hr);
+                : "ActivateCompleted reported failure");
         CoUninitialize();
-        m_running = false;
-        signalInit(false);
         return;
     }
 
@@ -470,22 +487,17 @@ void WasapiCapture::captureLoop() {
             );
             CoTaskMemFree(mixFmt);
             if (FAILED(hr2)) {
-                emitStatus(CaptureStatusKind::Failed,
-                    "IAudioClient::Initialize failed for both preferred and mix formats",
-                    hr2);
+                failStart(hr2,
+                    "IAudioClient::Initialize failed for both preferred and mix formats");
                 client->Release();
                 CoUninitialize();
-                m_running = false;
-                signalInit(false);
                 return;
             }
         } else {
-            emitStatus(CaptureStatusKind::Failed,
-                "Initialize failed and GetMixFormat returned no format", hr);
+            failStart(hr,
+                "Initialize failed and GetMixFormat returned no format");
             client->Release();
             CoUninitialize();
-            m_running = false;
-            signalInit(false);
             return;
         }
     }
@@ -494,25 +506,28 @@ void WasapiCapture::captureLoop() {
     IAudioCaptureClient* capture = nullptr;
     hr = client->GetService(__uuidof(IAudioCaptureClient), (void**)&capture);
     if (FAILED(hr)) {
-        emitStatus(CaptureStatusKind::Failed,
-            "GetService(IAudioCaptureClient) failed", hr);
+        failStart(hr,
+            "GetService(IAudioCaptureClient) failed");
         client->Release();
         CoUninitialize();
-        m_running = false;
-        signalInit(false);
         return;
     }
 
     hr = client->Start();
     if (FAILED(hr)) {
-        emitStatus(CaptureStatusKind::Failed, "IAudioClient::Start failed", hr);
+        failStart(hr, "IAudioClient::Start failed");
         capture->Release();
         client->Release();
         CoUninitialize();
-        m_running = false;
-        signalInit(false);
         return;
     }
+
+    {
+        std::lock_guard<std::mutex> startLock(m_startMutex);
+        m_startState = StartupState::Running;
+        m_startHr = S_OK;
+    }
+    m_startCv.notify_all();
 
     // Init succeeded — let StartCapture return true.
     {
@@ -524,7 +539,6 @@ void WasapiCapture::captureLoop() {
         OutputDebugStringA(dbg);
     }
     emitStatus(CaptureStatusKind::Started, "WASAPI process loopback active");
-    signalInit(true);
 
     // Emit one immediate silence packet so the renderer's "first packet
     // arrived" gate flips right away, even if the source app is silent.

--- a/native/src/win/wasapi_capture.h
+++ b/native/src/win/wasapi_capture.h
@@ -19,6 +19,7 @@
 #include <thread>
 #include <atomic>
 #include <mutex>
+#include <condition_variable>
 
 namespace haven {
 
@@ -37,6 +38,13 @@ public:
     void                  Cleanup()                    override;
 
 private:
+    enum class StartupState {
+        Idle,
+        Starting,
+        Running,
+        Failed
+    };
+
     void captureLoop();
     void emitStatus(CaptureStatusKind kind, const std::string& msg, int64_t code = 0);
 
@@ -48,11 +56,10 @@ private:
     CaptureMode       m_mode = CaptureMode::IncludeProcess;
     std::mutex        m_mutex;
 
-    // Set by StartCapture before the thread starts; the thread signals
-    // m_initEvent once activation either succeeds or hard-fails so the
-    // caller can return synchronously with an accurate result.
-    void*             m_initEvent = nullptr; // HANDLE
-    std::atomic<bool> m_initOk{false};
+    std::mutex              m_startMutex;
+    std::condition_variable m_startCv;
+    StartupState            m_startState{StartupState::Idle};
+    HRESULT                 m_startHr{S_OK};
 };
 
 } // namespace haven

--- a/src/main/app-preload.js
+++ b/src/main/app-preload.js
@@ -662,14 +662,14 @@ ipcRenderer.on('audio:capture-data', (_event, pcmData) => {
 
 // ─── Listen for screen-picker request from main process ──
 ipcRenderer.on('screen:show-picker', (_event, data) => {
-  showScreenPicker(data.sources, data.audioApps);
+  showScreenPicker(data?.sources || [], data?.audioApps || [], data?.requestId || null);
 });
 
 // ═══════════════════════════════════════════════════════════
 // Screen-Share Picker  (injected as a full-screen overlay)
 // ═══════════════════════════════════════════════════════════
 
-function showScreenPicker(sources, audioApps) {
+function showScreenPicker(sources, audioApps, requestId) {
   // Remove stale picker
   document.getElementById('haven-screen-picker')?.remove();
 
@@ -698,6 +698,9 @@ function showScreenPicker(sources, audioApps) {
       .hsp-src.sel{border-color:#6b4fdb}
       .hsp-src img{width:100%;border-radius:4px;margin-bottom:6px;aspect-ratio:16/9;
         object-fit:cover;background:#0d0d1a}
+      .hsp-src .hsp-thumb-ph{width:100%;border-radius:4px;margin-bottom:6px;aspect-ratio:16/9;
+        background:linear-gradient(135deg,#0d0d1a,#1a1a2e);display:flex;align-items:center;
+        justify-content:center;color:#777;font-size:11px;letter-spacing:.3px}
       .hsp-src-name{color:#ccc;font-size:12px;text-align:center;white-space:nowrap;
         overflow:hidden;text-overflow:ellipsis}
       .hsp-audio{padding-top:14px;border-top:1px solid #2a2a4a;flex-shrink:0;margin-top:10px}
@@ -757,7 +760,10 @@ function showScreenPicker(sources, audioApps) {
   sources.forEach(src => {
     const el = document.createElement('div');
     el.className = 'hsp-src';
-    el.innerHTML = `<img src="${src.thumbnail}" alt=""><div class="hsp-src-name" title="${src.name}">${src.name}</div>`;
+    const preview = src.thumbnail
+      ? `<img src="${src.thumbnail}" alt="">`
+      : `<div class="hsp-thumb-ph">No preview</div>`;
+    el.innerHTML = `${preview}<div class="hsp-src-name" title="${src.name}">${src.name}</div>`;
     el.onclick = () => {
       overlay.querySelectorAll('.hsp-src.sel').forEach(s => s.classList.remove('sel'));
       el.classList.add('sel');
@@ -846,7 +852,9 @@ function showScreenPicker(sources, audioApps) {
       }
     }
 
-    ipcRenderer.send('screen:picker-result', cancelled ? { cancelled: true } : { sourceId: selSource, audioAppPid: effectiveAudioPid });
+    ipcRenderer.send('screen:picker-result', cancelled
+      ? { requestId, cancelled: true }
+      : { requestId, sourceId: selSource, audioAppPid: effectiveAudioPid });
   };
 
   document.getElementById('hsp-cancel').onclick = () => dismiss(true);
@@ -1138,7 +1146,31 @@ function installGetDisplayMediaOverride() {
           console.log(`[Haven Desktop] waiting for first PCM packet... elapsed=${Date.now() - start}ms received=${_audioPacketsReceived} status=${_lastNativeStatus?.kind || 'none'}`);
         }
         await new Promise(resolve => setTimeout(resolve, stepMs));
-      }\n\n      if (_audioPacketsReceived > 0 && window._havenAppAudioTrack) {\n        // Native pipeline succeeded \u2014 NOW it's safe to drop Electron's\n        // loopback and substitute the clean per-app / exclude-mode track.\n        stream.getAudioTracks().forEach(t => { try { stream.removeTrack(t); t.stop(); } catch {} });\n        stream.addTrack(window._havenAppAudioTrack);\n        console.log(`[Haven Desktop] per-app/system-exclude audio track added (waited ${Date.now() - start}ms, ${_audioPacketsReceived} PCM chunks received)`);\n      } else {\n        // Native capture failed.  KEEP Electron's loopback track so the\n        // share is audible.  Yes, this can include Haven's own voice\n        // output (echo risk) but silence is worse \u2014 the share-audio-mode\n        // badge / toast will already warn the user.\n        console.warn('[Haven Desktop] readiness wait expired without PCM. Diagnostics:');\n        console.warn('  capturedAudioPid:', _capturedAudioPid);\n        console.warn('  packetsReceived:', _audioPacketsReceived);\n        console.warn('  ipcDataCount:', _ipcDataCount);\n        console.warn('  havenAppAudioTrack present:', !!window._havenAppAudioTrack);\n        console.warn('  audioCtx state:', _audioCtx?.state);\n        console.warn('  audioWorkletNode present:', !!_audioWorkletNode);\n        console.warn('  havenAppAudioPush present:', !!window._havenAppAudioPush);\n        console.warn('  lastNativeStatus:', _lastNativeStatus);\n        console.warn('  Falling back to Electron loopback audio so share isn\\'t silent (Haven voice loop possible).');\n      }\n    } else if (window._havenAppAudioTrack) {
+      }
+
+      if (_audioPacketsReceived > 0 && window._havenAppAudioTrack) {
+        // Native pipeline succeeded — NOW it's safe to drop Electron's
+        // loopback and substitute the clean per-app / exclude-mode track.
+        stream.getAudioTracks().forEach(t => { try { stream.removeTrack(t); t.stop(); } catch {} });
+        stream.addTrack(window._havenAppAudioTrack);
+        console.log(`[Haven Desktop] per-app/system-exclude audio track added (waited ${Date.now() - start}ms, ${_audioPacketsReceived} PCM chunks received)`);
+      } else {
+        // Native capture failed.  KEEP Electron's loopback track so the
+        // share is audible.  Yes, this can include Haven's own voice
+        // output (echo risk) but silence is worse — the share-audio-mode
+        // badge / toast will already warn the user.
+        console.warn('[Haven Desktop] readiness wait expired without PCM. Diagnostics:');
+        console.warn('  capturedAudioPid:', _capturedAudioPid);
+        console.warn('  packetsReceived:', _audioPacketsReceived);
+        console.warn('  ipcDataCount:', _ipcDataCount);
+        console.warn('  havenAppAudioTrack present:', !!window._havenAppAudioTrack);
+        console.warn('  audioCtx state:', _audioCtx?.state);
+        console.warn('  audioWorkletNode present:', !!_audioWorkletNode);
+        console.warn('  havenAppAudioPush present:', !!window._havenAppAudioPush);
+        console.warn('  lastNativeStatus:', _lastNativeStatus);
+        console.warn('  Falling back to Electron loopback audio so share isn\'t silent (Haven voice loop possible).');
+      }
+    } else if (window._havenAppAudioTrack) {
       // Defensive: a per-app track exists but no _capturedAudioPid was set.
       // Prefer per-app over loopback to be safe.
       stream.getAudioTracks().forEach(t => { try { stream.removeTrack(t); t.stop(); } catch {} });

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1250,13 +1250,35 @@ function createTray() {
 
 function registerScreenShareHandler() {
   session.defaultSession.setDisplayMediaRequestHandler(async (request, callback) => {
+    let callbackUsed = false;
+    const safeCallback = (payload) => {
+      if (callbackUsed) {
+        console.warn('[ScreenShare] callback already used; ignoring duplicate invoke');
+        return;
+      }
+      callbackUsed = true;
+      callback(payload);
+    };
+
     try {
       // Video sources
-      const sources = await desktopCapturer.getSources({
-        types: ['window', 'screen'],
-        thumbnailSize: { width: 320, height: 180 },
-        fetchWindowIcons: true,
-      });
+      let sources;
+      try {
+        sources = await desktopCapturer.getSources({
+          types: ['window', 'screen'],
+          thumbnailSize: { width: 320, height: 180 },
+          fetchWindowIcons: true,
+        });
+      } catch (err) {
+        // Some Windows builds intermittently fail WGC thumbnail startup
+        // with E_INVALIDARG. Retry without thumbnails so the picker can open.
+        console.warn(`[ScreenShare] getSources(thumbnails) failed: ${err.message}; retrying without thumbnails`);
+        sources = await desktopCapturer.getSources({
+          types: ['window', 'screen'],
+          thumbnailSize: { width: 0, height: 0 },
+          fetchWindowIcons: false,
+        });
+      }
 
       // Audio-producing applications (native addon)
       let audioApps = [];
@@ -1266,28 +1288,55 @@ function registerScreenShareHandler() {
       const sourceData = sources.map(s => ({
         id:         s.id,
         name:       s.name,
-        thumbnail:  s.thumbnail.toDataURL(),
+        thumbnail:  (s.thumbnail && !s.thumbnail.isEmpty()) ? s.thumbnail.toDataURL() : null,
         appIcon:    s.appIcon ? s.appIcon.toDataURL() : null,
         display_id: s.display_id,
       }));
+      console.log(`[ScreenShare] source enumeration complete: ${sourceData.length} source(s)`);
 
-      const targetContents = getActiveContents();
-      if (!targetContents) { callback({}); return; }
+      const requestFrame = request?.frame;
+      const targetContents = requestFrame?.host || getActiveContents();
+      if (!targetContents) { safeCallback({}); return; }
+
+      const requestId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 
       // Ask renderer to show the picker
-      safeSend(targetContents, 'screen:show-picker', { sources: sourceData, audioApps });
+      let sentToFrame = false;
+      if (requestFrame && !requestFrame.isDestroyed()) {
+        try {
+          requestFrame.send('screen:show-picker', { requestId, sources: sourceData, audioApps });
+          sentToFrame = true;
+          console.log('[ScreenShare] picker request sent to request.frame');
+        } catch (err) {
+          console.warn(`[ScreenShare] request.frame send failed: ${err.message}`);
+        }
+      }
+      const frameHostId = requestFrame?.host?.id;
+      const targetId = targetContents?.id;
+      if (!sentToFrame || frameHostId !== targetId) {
+        safeSend(targetContents, 'screen:show-picker', { requestId, sources: sourceData, audioApps });
+        console.log('[ScreenShare] picker request sent to target webContents fallback');
+      }
 
       // Wait for picker result (or 60 s timeout)
       const result = await new Promise(resolve => {
-        const handler = (_e, res) => resolve(res);
-        ipcMain.once('screen:picker-result', handler);
-        setTimeout(() => { ipcMain.removeListener('screen:picker-result', handler); resolve({ cancelled: true }); }, 60000);
+        const handler = (_e, res = {}) => {
+          if (res.requestId !== requestId) return;
+          clearTimeout(timeoutId);
+          ipcMain.removeListener('screen:picker-result', handler);
+          resolve(res);
+        };
+        const timeoutId = setTimeout(() => {
+          ipcMain.removeListener('screen:picker-result', handler);
+          resolve({ cancelled: true, requestId });
+        }, 60000);
+        ipcMain.on('screen:picker-result', handler);
       });
 
-      if (result.cancelled) { callback({}); return; }
+      if (result.cancelled) { safeCallback({}); return; }
 
       const selected = sources.find(s => s.id === result.sourceId);
-      if (!selected) { callback({}); return; }
+      if (!selected) { safeCallback({}); return; }
 
       // Decide capture path based on picker result.
       //   audioAppPid > 0  → INCLUDE-mode capture of that PID
@@ -1403,14 +1452,14 @@ function registerScreenShareHandler() {
       //   alternative is users wondering why no one can hear their game.
       //   The renderer toast / share-mode badge will warn them.
       if (appliedMode === 'none') {
-        callback({ video: selected });
+        safeCallback({ video: selected });
       } else {
-        callback({ video: selected, audio: 'loopback' });
+        safeCallback({ video: selected, audio: 'loopback' });
       }
 
     } catch (err) {
       console.error('[ScreenShare] handler error:', err);
-      callback({});
+      safeCallback({});
     }
   });
 }


### PR DESCRIPTION
I tested the new per-app audio code in 1.4.5 and it's still failing on my windows systems.
I had created a PR with the fix, this PR carries those same fixes over to 1.4.7

**Why this is still needed**
I pulled the latest upstream changes for per-app audio, but on Windows I was still getting a hard failure during readiness wait, which led to silent sharing.

Before this patch, the flow looked like:
```
\vscode\Haven-Desktop\src\main\app-preload.js:837 [Haven Desktop] Picker dismissed: building native audio pipeline for 38192
\vscode\Haven-Desktop\src\main\app-preload.js:964 [Haven Desktop] Per-app audio pipeline active (AudioWorklet), ctx state: running
\vscode\Haven-Desktop\src\main\app-preload.js:615 [Haven Desktop] share audio mode: {requested: 'app', applied: 'system-loopback', detail: 'native capture unavailable: unknown'}
\vscode\Haven-Desktop\src\main\app-preload.js:608 [Haven Desktop] native capture status: kind=starting code=0x0 msg=activating INCLUDE-mode process loopback for PID 38192
\vscode\Haven-Desktop\src\main\app-preload.js:608 [Haven Desktop] native capture status: kind=failed code=0x8000000e msg=ActivateAudioInterfaceAsync returned failure (process loopback API may be unavailable)
\vscode\Haven-Desktop\src\main\app-preload.js:608 [Haven Desktop] native capture status: kind=starting code=0x0 msg=activating EXCLUDE-mode process loopback for PID 44612
\vscode\Haven-Desktop\src\main\app-preload.js:608 [Haven Desktop] native capture status: kind=failed code=0x8000000e msg=ActivateAudioInterfaceAsync returned failure (process loopback API may be unavailable)
\vscode\Haven-Desktop\src\main\app-preload.js:1114 [Haven Desktop] getDisplayMedia resolved (capturedAudioPid=38192, electron-audio-tracks=1, per-app track ready=true)
\vscode\Haven-Desktop\src\main\app-preload.js:1132 [Haven Desktop] native capture reported FAILED during readiness wait — aborting wait
navigator.mediaDevices.getDisplayMedia @ \vscode\Haven-Desktop\src\main\app-preload.js:1132
await in navigator.mediaDevices.getDisplayMedia
shareScreen @ voice.js?v=3.4.0:422
_toggleScreenShare @ app-voice.js?v=2.7.10:283
(anonymous) @ app-ui.js?v=2.7.13:835
\vscode\Haven-Desktop\src\main\app-preload.js:1152 [Haven Desktop] readiness wait expired without PCM. Diagnostics:
navigator.mediaDevices.getDisplayMedia @ \vscode\Haven-Desktop\src\main\app-preload.js:1152
await in navigator.mediaDevices.getDisplayMedia
shareScreen @ voice.js?v=3.4.0:422
_toggleScreenShare @ app-voice.js?v=2.7.10:283
(anonymous) @ app-ui.js?v=2.7.13:835
\vscode\Haven-Desktop\src\main\app-preload.js:1153   capturedAudioPid: 38192
navigator.mediaDevices.getDisplayMedia @ \vscode\Haven-Desktop\src\main\app-preload.js:1153
await in navigator.mediaDevices.getDisplayMedia
shareScreen @ voice.js?v=3.4.0:422
_toggleScreenShare @ app-voice.js?v=2.7.10:283
(anonymous) @ app-ui.js?v=2.7.13:835
\vscode\Haven-Desktop\src\main\app-preload.js:1154   packetsReceived: 0
navigator.mediaDevices.getDisplayMedia @ \vscode\Haven-Desktop\src\main\app-preload.js:1154
await in navigator.mediaDevices.getDisplayMedia
shareScreen @ voice.js?v=3.4.0:422
_toggleScreenShare @ app-voice.js?v=2.7.10:283
(anonymous) @ app-ui.js?v=2.7.13:835
\vscode\Haven-Desktop\src\main\app-preload.js:1155   ipcDataCount: 0
navigator.mediaDevices.getDisplayMedia @ \vscode\Haven-Desktop\src\main\app-preload.js:1155
await in navigator.mediaDevices.getDisplayMedia
shareScreen @ voice.js?v=3.4.0:422
_toggleScreenShare @ app-voice.js?v=2.7.10:283
(anonymous) @ app-ui.js?v=2.7.13:835
\vscode\Haven-Desktop\src\main\app-preload.js:1156   havenAppAudioTrack present: true
navigator.mediaDevices.getDisplayMedia @ \vscode\Haven-Desktop\src\main\app-preload.js:1156
await in navigator.mediaDevices.getDisplayMedia
shareScreen @ voice.js?v=3.4.0:422
_toggleScreenShare @ app-voice.js?v=2.7.10:283
(anonymous) @ app-ui.js?v=2.7.13:835
\vscode\Haven-Desktop\src\main\app-preload.js:1157   audioCtx state: running
navigator.mediaDevices.getDisplayMedia @ \vscode\Haven-Desktop\src\main\app-preload.js:1157
await in navigator.mediaDevices.getDisplayMedia
shareScreen @ voice.js?v=3.4.0:422
_toggleScreenShare @ app-voice.js?v=2.7.10:283
(anonymous) @ app-ui.js?v=2.7.13:835
\vscode\Haven-Desktop\src\main\app-preload.js:1158   audioWorkletNode present: true
navigator.mediaDevices.getDisplayMedia @ \vscode\Haven-Desktop\src\main\app-preload.js:1158
await in navigator.mediaDevices.getDisplayMedia
shareScreen @ voice.js?v=3.4.0:422
_toggleScreenShare @ app-voice.js?v=2.7.10:283
(anonymous) @ app-ui.js?v=2.7.13:835
\vscode\Haven-Desktop\src\main\app-preload.js:1159   havenAppAudioPush present: false
navigator.mediaDevices.getDisplayMedia @ \vscode\Haven-Desktop\src\main\app-preload.js:1159
await in navigator.mediaDevices.getDisplayMedia
shareScreen @ voice.js?v=3.4.0:422
_toggleScreenShare @ app-voice.js?v=2.7.10:283
(anonymous) @ app-ui.js?v=2.7.13:835
\vscode\Haven-Desktop\src\main\app-preload.js:1160   lastNativeStatus: {kind: 'failed', message: 'ActivateAudioInterfaceAsync returned failure (process loopback API may be unavailable)', code: -2147483634}
navigator.mediaDevices.getDisplayMedia @ \vscode\Haven-Desktop\src\main\app-preload.js:1160
await in navigator.mediaDevices.getDisplayMedia
shareScreen @ voice.js?v=3.4.0:422
_toggleScreenShare @ app-voice.js?v=2.7.10:283
(anonymous) @ app-ui.js?v=2.7.13:835
\vscode\Haven-Desktop\src\main\app-preload.js:1161   Share will be SILENT (no system-loopback fallback to avoid voice loop).
navigator.mediaDevices.getDisplayMedia @ \vscode\Haven-Desktop\src\main\app-preload.js:1161
await in navigator.mediaDevices.getDisplayMedia
shareScreen @ voice.js?v=3.4.0:422
_toggleScreenShare @ app-voice.js?v=2.7.10:283
(anonymous) @ app-ui.js?v=2.7.13:835
```

**What this patch adds**
This ports the relevant Windows-native fixes from my earlier branch/PR into current upstream-main:

- more robust WASAPI async activation handling for process loopback startup
- explicit startup state sync so StartCapture waits for real success/failure
- safer N-API callback buffer ownership when sending PCM to JS

**Result after patch**
After applying these changes on the same machine and same target app/PID, startup now completes and audio data flows:

```
[Haven Desktop] Picker dismissed: building native audio pipeline for 38192
\Haven-Desktop\src\main\app-preload.js:964 [Haven Desktop] Per-app audio pipeline active (AudioWorklet), ctx state: running
\Haven-Desktop\src\main\app-preload.js:615 [Haven Desktop] share audio mode: {requested: 'app', applied: 'app', detail: 'firefox'}
\Haven-Desktop\src\main\app-preload.js:608 [Haven Desktop] native capture status: kind=starting code=0x0 msg=activating INCLUDE-mode process loopback for PID 38192
\Haven-Desktop\src\main\app-preload.js:608 [Haven Desktop] native capture status: kind=started code=0x0 msg=WASAPI process loopback active
\Haven-Desktop\src\main\app-preload.js:650 [Haven Desktop] audio:capture-data chunk #1, 480 samples, peak=0.0000
\Haven-Desktop\src\main\app-preload.js:1114 [Haven Desktop] getDisplayMedia resolved (capturedAudioPid=38192, electron-audio-tracks=0, per-app track ready=true)
\Haven-Desktop\src\main\app-preload.js:1144 [Haven Desktop] per-app/system-exclude audio track added 
```