### PR TITLE
Fix/screen share audio controls

### DIFF
--- a/native/binding.gyp
+++ b/native/binding.gyp
@@ -4,9 +4,9 @@
       "target_name": "haven_audio",
       "cflags!":    ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
-      "sources":    ["src/addon.cpp"],
+      "sources":    ["src/addon.cpp", "src/unsupported_capture.cpp"],
       "include_dirs": [
-        "<!@(node -p \"require('node-addon-api').include\")"
+        "../node_modules/node-addon-api"
       ],
       "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],
       "conditions": [

--- a/native/src/addon.cpp
+++ b/native/src/addon.cpp
@@ -56,7 +56,7 @@ static Napi::Value StartCapture(const Napi::CallbackInfo& info) {
     // Accept either:
     //   startCapture(pid, dataCb)                         (legacy, INCLUDE)
     //   startCapture(pid, mode, dataCb [, statusCb])      (new)
-    // mode is a string: "include" or "exclude"
+    // mode is a string: "include", "exclude", or "system"
     if (info.Length() < 2 || !info[0].IsNumber()) {
         Napi::TypeError::New(env, "startCapture(pid, [mode], dataCb, [statusCb])")
             .ThrowAsJavaScriptException();
@@ -72,6 +72,7 @@ static Napi::Value StartCapture(const Napi::CallbackInfo& info) {
     if (info[1].IsString()) {
         std::string m = info[1].As<Napi::String>().Utf8Value();
         if (m == "exclude") mode = haven::CaptureMode::ExcludeProcess;
+        if (m == "system") mode = haven::CaptureMode::SystemLoopback;
         if (info.Length() < 3 || !info[2].IsFunction()) {
             Napi::TypeError::New(env, "startCapture(pid, mode, dataCb, [statusCb])")
                 .ThrowAsJavaScriptException();

--- a/native/src/addon.cpp
+++ b/native/src/addon.cpp
@@ -13,6 +13,8 @@
 #include "audio_capture.h"
 #include <memory>
 #include <cstring>
+#include <chrono>
+#include <vector>
 
 static std::unique_ptr<haven::IAudioCapture> g_capture;
 
@@ -49,6 +51,11 @@ static Napi::Value GetAudioApplications(const Napi::CallbackInfo& info) {
 // data to the JS thread via Napi::ThreadSafeFunction.
 static Napi::ThreadSafeFunction g_tsfn;
 static Napi::ThreadSafeFunction g_statusTsfn;
+
+struct PendingAudioChunk {
+    std::vector<float> samples;
+    int64_t capturedAtMs;
+};
 
 static Napi::Value StartCapture(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
@@ -95,9 +102,11 @@ static Napi::Value StartCapture(const Napi::CallbackInfo& info) {
         return env.Undefined();
     }
 
-    g_tsfn = Napi::ThreadSafeFunction::New(env, jsCb, "HavenAudioCapture", 0, 1);
+    // At 10 ms per chunk, four pending calls cap native-to-JS backlog at
+    // roughly 40 ms. NonBlockingCall drops new chunks if JS falls behind.
+    g_tsfn = Napi::ThreadSafeFunction::New(env, jsCb, "HavenAudioCapture", 4, 1);
     if (haveStatusCb) {
-        g_statusTsfn = Napi::ThreadSafeFunction::New(env, jsStatusCb, "HavenAudioStatus", 0, 1);
+        g_statusTsfn = Napi::ThreadSafeFunction::New(env, jsStatusCb, "HavenAudioStatus", 8, 1);
     }
 
     haven::AudioDataCb nativeCb = [](const float* data, size_t count) {
@@ -105,20 +114,24 @@ static Napi::Value StartCapture(const Napi::CallbackInfo& info) {
             return;
         }
 
-        float* copy = new float[count];
-        std::memcpy(copy, data, count * sizeof(float));
+        auto* chunk = new PendingAudioChunk();
+        chunk->samples.assign(data, data + count);
+        chunk->capturedAtMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
 
-        napi_status status = g_tsfn.NonBlockingCall(copy, [count](Napi::Env env, Napi::Function fn, float* buf) {
+        napi_status status = g_tsfn.NonBlockingCall(chunk,
+            [](Napi::Env env, Napi::Function fn, PendingAudioChunk* pending) {
             // Use JS-owned backing memory to avoid external buffer lifetime issues.
+            const size_t count = pending->samples.size();
             Napi::ArrayBuffer ab = Napi::ArrayBuffer::New(env, count * sizeof(float));
-            std::memcpy(ab.Data(), buf, count * sizeof(float));
-            delete[] buf;
+            std::memcpy(ab.Data(), pending->samples.data(), count * sizeof(float));
             Napi::Float32Array f32 = Napi::Float32Array::New(env, count, ab, 0);
-            fn.Call({ f32 });
+            fn.Call({ f32, Napi::Number::New(env, static_cast<double>(pending->capturedAtMs)) });
+            delete pending;
         });
 
         if (status != napi_ok) {
-            delete[] copy;
+            delete chunk;
         }
     };
 
@@ -127,7 +140,7 @@ static Napi::Value StartCapture(const Napi::CallbackInfo& info) {
         nativeStatusCb = [](const haven::CaptureStatus& s) {
             // Box on heap so we can ferry across threads.
             auto* boxed = new haven::CaptureStatus(s);
-            g_statusTsfn.NonBlockingCall(boxed,
+            const napi_status status = g_statusTsfn.NonBlockingCall(boxed,
                 [](Napi::Env env, Napi::Function fn, haven::CaptureStatus* st) {
                     Napi::Object obj = Napi::Object::New(env);
                     const char* k = "?";
@@ -143,6 +156,7 @@ static Napi::Value StartCapture(const Napi::CallbackInfo& info) {
                     fn.Call({ obj });
                     delete st;
                 });
+            if (status != napi_ok) delete boxed;
         };
     }
 

--- a/native/src/audio_capture.h
+++ b/native/src/audio_capture.h
@@ -43,8 +43,8 @@ using CaptureStatusCb = std::function<void(const CaptureStatus&)>;
 // What kind of capture do we want?
 //   IncludeProcess: capture audio FROM the given PID (and its children)
 //   ExcludeProcess: capture ALL system audio EXCEPT the given PID tree
-//                   (Windows-only; Linux reports a Failed status.)
-//   SystemLoopback: capture the default output monitor (Linux).
+//                   (Windows process loopback; Linux isolated routing.)
+//   SystemLoopback: raw default-output monitor (internal Linux fallback only).
 enum class CaptureMode {
     IncludeProcess,
     ExcludeProcess,

--- a/native/src/audio_capture.h
+++ b/native/src/audio_capture.h
@@ -43,11 +43,12 @@ using CaptureStatusCb = std::function<void(const CaptureStatus&)>;
 // What kind of capture do we want?
 //   IncludeProcess: capture audio FROM the given PID (and its children)
 //   ExcludeProcess: capture ALL system audio EXCEPT the given PID tree
-//                   (Windows-only; falls back to IncludeProcess elsewhere
-//                    with a Failed status for Linux callers.)
+//                   (Windows-only; Linux reports a Failed status.)
+//   SystemLoopback: capture the default output monitor (Linux).
 enum class CaptureMode {
     IncludeProcess,
     ExcludeProcess,
+    SystemLoopback,
 };
 
 // Abstract per-platform audio capture

--- a/native/src/linux/pulse_capture.cpp
+++ b/native/src/linux/pulse_capture.cpp
@@ -48,6 +48,32 @@ static std::string procName(uint32_t pid) {
     return "Unknown";
 }
 
+static uint32_t procParentPid(uint32_t pid) {
+    std::ifstream f("/proc/" + std::to_string(pid) + "/stat");
+    std::string line;
+    if (!f.is_open() || !std::getline(f, line)) return 0;
+
+    // The command is parenthesized and may contain spaces. Fields after the
+    // final ')' start with state, then parent PID.
+    const size_t commandEnd = line.rfind(')');
+    if (commandEnd == std::string::npos || commandEnd + 2 >= line.size()) return 0;
+    std::istringstream fields(line.substr(commandEnd + 2));
+    char state = 0;
+    uint32_t parent = 0;
+    fields >> state >> parent;
+    return parent;
+}
+
+static bool isProcessInTree(uint32_t pid, uint32_t rootPid) {
+    for (int depth = 0; pid != 0 && depth < 64; depth++) {
+        if (pid == rootPid) return true;
+        const uint32_t parent = procParentPid(pid);
+        if (parent == pid) break;
+        pid = parent;
+    }
+    return false;
+}
+
 // Synchronous PulseAudio helper — runs main loop until callback signals done
 struct PaSync {
     pa_mainloop*     ml  = nullptr;
@@ -132,9 +158,14 @@ static void moduleLoadCb(pa_context*, uint32_t idx, void* ud) {
 }
 
 // Success callback
-struct OpDone { bool done = false; };
-static void successCb(pa_context*, int, void* ud) {
-    ((OpDone*)ud)->done = true;
+struct OpDone {
+    bool done = false;
+    bool success = false;
+};
+static void successCb(pa_context*, int success, void* ud) {
+    auto* result = static_cast<OpDone*>(ud);
+    result->success = success != 0;
+    result->done = true;
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -169,12 +200,10 @@ void PulseCapture::emitStatus(CaptureStatusKind kind, const std::string& msg, in
 }
 
 bool PulseCapture::IsSupported() const {
-    // Check if PulseAudio is available
-    pa_simple* s = nullptr;
-    pa_sample_spec ss = { PA_SAMPLE_FLOAT32LE, 48000, 1 };
-    s = pa_simple_new(nullptr, "HavenProbe", PA_STREAM_RECORD, nullptr, "probe", &ss, nullptr, nullptr, nullptr);
-    if (s) { pa_simple_free(s); return true; }
-    return false;
+    // Capability checks must not open the default recording source (usually
+    // the microphone). A control connection is enough for both capture modes.
+    PaSync pa;
+    return pa.connect();
 }
 
 std::vector<AudioApp> PulseCapture::GetAudioApplications() {
@@ -194,8 +223,10 @@ std::vector<AudioApp> PulseCapture::GetAudioApplications() {
 
     // Deduplicate by PID
     std::vector<uint32_t> seen;
+    const uint32_t ourPid = static_cast<uint32_t>(getpid());
     for (auto& si : ed.inputs) {
         if (si.pid == 0) continue;
+        if (isProcessInTree(si.pid, ourPid)) continue;
         if (std::find(seen.begin(), seen.end(), si.pid) != seen.end()) continue;
         seen.push_back(si.pid);
 
@@ -235,7 +266,9 @@ bool PulseCapture::StartCapture(uint32_t pid, CaptureMode mode,
     }
 
     emitStatus(CaptureStatusKind::Starting,
-        "preparing pulse capture for PID " + std::to_string(pid));
+        mode == CaptureMode::SystemLoopback
+            ? "preparing pulse system capture"
+            : "preparing pulse capture for PID " + std::to_string(pid));
 
     m_thread = std::thread([this]() { captureLoop(); });
     return true;
@@ -282,6 +315,71 @@ void PulseCapture::captureLoop() {
         emitStatus(CaptureStatusKind::Failed,
             "pa_context_connect failed (PulseAudio/PipeWire daemon not reachable)");
         m_running = false;
+        return;
+    }
+
+    if (m_mode == CaptureMode::SystemLoopback) {
+        struct DefaultSinkInfo {
+            std::string name;
+            bool done = false;
+        } sink;
+        auto serverInfoCb = [](pa_context*, const pa_server_info* info, void* ud) {
+            auto* result = static_cast<DefaultSinkInfo*>(ud);
+            if (info && info->default_sink_name) result->name = info->default_sink_name;
+            result->done = true;
+        };
+
+        pa_operation* op = pa_context_get_server_info(pa.ctx, serverInfoCb, &sink);
+        if (!op) {
+            emitStatus(CaptureStatusKind::Failed, "PulseAudio could not read the default output");
+            m_running = false;
+            return;
+        }
+        while (!sink.done) pa.iterateBlock();
+        pa_operation_unref(op);
+        if (sink.name.empty()) {
+            emitStatus(CaptureStatusKind::Failed, "PulseAudio has no default output");
+            m_running = false;
+            return;
+        }
+
+        const std::string monitor = sink.name + ".monitor";
+        pa_sample_spec ss = { PA_SAMPLE_FLOAT32LE, 48000, 1 };
+        int err = 0;
+        pa_simple* rec = pa_simple_new(
+            nullptr, "HavenDesktop", PA_STREAM_RECORD,
+            monitor.c_str(), "System Audio Capture",
+            &ss, nullptr, nullptr, &err
+        );
+        if (!rec) {
+            emitStatus(CaptureStatusKind::Failed,
+                std::string("pa_simple_new failed: ") + pa_strerror(err), err);
+            m_running = false;
+            return;
+        }
+
+        emitStatus(CaptureStatusKind::Started, "pulse system capture active");
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_callback) {
+                std::vector<float> silence(480, 0.0f);
+                m_callback(silence.data(), silence.size());
+            }
+        }
+
+        const size_t chunkFrames = 480;
+        std::vector<float> buf(chunkFrames);
+        while (m_running) {
+            if (pa_simple_read(rec, buf.data(), chunkFrames * sizeof(float), &err) < 0) {
+                emitStatus(CaptureStatusKind::Failed,
+                    std::string("PulseAudio system capture failed: ") + pa_strerror(err), err);
+                m_running = false;
+                break;
+            }
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_callback) m_callback(buf.data(), chunkFrames);
+        }
+        pa_simple_free(rec);
         return;
     }
 
@@ -341,11 +439,19 @@ void PulseCapture::captureLoop() {
         "sink_properties=device.description=\"Haven\\ Per-App\\ Capture\" "
         "rate=48000 channels=1 format=float32le",
         moduleLoadCb, &nullRes);
-    if (!op) { m_running = false; return; }
+    if (!op) {
+        emitStatus(CaptureStatusKind::Failed, "PulseAudio could not create the capture output");
+        m_running = false;
+        return;
+    }
     while (!nullRes.done) pa.iterateBlock();
     pa_operation_unref(op);
 
-    if (nullRes.index == PA_INVALID_INDEX) { m_running = false; return; }
+    if (nullRes.index == PA_INVALID_INDEX) {
+        emitStatus(CaptureStatusKind::Failed, "PulseAudio rejected the capture output");
+        m_running = false;
+        return;
+    }
     m_nullSinkModule = nullRes.index;
 
     // ── Look up the null sink index ───────────────────────
@@ -369,6 +475,7 @@ void PulseCapture::captureLoop() {
         op = pa_context_unload_module(pa.ctx, m_nullSinkModule, successCb, &od);
         if (op) { while (!od.done) pa.iterateBlock(); pa_operation_unref(op); }
         m_nullSinkModule = 0;
+        emitStatus(CaptureStatusKind::Failed, "PulseAudio could not find the capture output");
         m_running = false;
         return;
     }
@@ -384,6 +491,17 @@ void PulseCapture::captureLoop() {
 
     op = pa_context_get_sink_info_by_index(pa.ctx, originalSink, sinkNameCb, &origSinkLookup);
     if (op) { while (!origSinkLookup.done) pa.iterateBlock(); pa_operation_unref(op); }
+
+    if (isPipeWire && origSinkLookup.name.empty()) {
+        OpDone od;
+        op = pa_context_unload_module(pa.ctx, m_nullSinkModule, successCb, &od);
+        if (op) { while (!od.done) pa.iterateBlock(); pa_operation_unref(op); }
+        m_nullSinkModule = 0;
+        emitStatus(CaptureStatusKind::Failed,
+            "PipeWire could not identify the selected application's output");
+        m_running = false;
+        return;
+    }
 
     // ── Step 3: Route audio ───────────────────────────────
     //
@@ -432,28 +550,30 @@ void PulseCapture::captureLoop() {
                 OpDone od;
                 op = pa_context_move_sink_input_by_index(pa.ctx, targetSinkInput, csl.idx, successCb, &od);
                 if (op) { while (!od.done) pa.iterateBlock(); pa_operation_unref(op); }
-                combineSinkOk = true;
+                combineSinkOk = od.success;
             }
         }
 
         if (!combineSinkOk) {
-            // Combine-sink failed — fall back to loopback from original sink's
-            // monitor.  This captures ALL audio on that output device (not just
-            // the target app), but it won't crash.
-            fprintf(stderr, "[Haven AudioCapture] combine-sink unavailable on PipeWire — falling back to loopback\n");
-            // Clean up failed combine-sink module if it was partially loaded
+            // Never fall back to the output monitor here: that would turn an
+            // application-only choice into a capture of every app, including
+            // Haven voice output.
             if (m_loopbackModule != 0) {
                 OpDone od2;
                 auto* unOp = pa_context_unload_module(pa.ctx, m_loopbackModule, successCb, &od2);
                 if (unOp) { while (!od2.done) pa.iterateBlock(); pa_operation_unref(unOp); }
                 m_loopbackModule = 0;
             }
-            // Loopback from original sink's monitor → HavenCapture
-            ModuleLoadResult lbRes;
-            std::string args = "source=" + origSinkLookup.name + ".monitor sink=HavenCapture sink_dont_move=true";
-            op = pa_context_load_module(pa.ctx, "module-loopback", args.c_str(), moduleLoadCb, &lbRes);
-            if (op) { while (!lbRes.done) pa.iterateBlock(); pa_operation_unref(op); }
-            m_loopbackModule = lbRes.index;
+            if (m_nullSinkModule != 0) {
+                OpDone od2;
+                auto* unOp = pa_context_unload_module(pa.ctx, m_nullSinkModule, successCb, &od2);
+                if (unOp) { while (!od2.done) pa.iterateBlock(); pa_operation_unref(unOp); }
+                m_nullSinkModule = 0;
+            }
+            emitStatus(CaptureStatusKind::Failed,
+                "PipeWire could not isolate the selected application audio");
+            m_running = false;
+            return;
         }
     } else {
         // Classic PulseAudio: move sink input to null sink directly
@@ -461,6 +581,16 @@ void PulseCapture::captureLoop() {
             OpDone od;
             op = pa_context_move_sink_input_by_index(pa.ctx, targetSinkInput, sl.idx, successCb, &od);
             if (op) { while (!od.done) pa.iterateBlock(); pa_operation_unref(op); }
+            if (!od.success) {
+                OpDone unload;
+                op = pa_context_unload_module(pa.ctx, m_nullSinkModule, successCb, &unload);
+                if (op) { while (!unload.done) pa.iterateBlock(); pa_operation_unref(op); }
+                m_nullSinkModule = 0;
+                emitStatus(CaptureStatusKind::Failed,
+                    "PulseAudio could not isolate the selected application audio");
+                m_running = false;
+                return;
+            }
         }
 
         // Loopback null sink → default output so user still hears the app

--- a/native/src/linux/pulse_capture.cpp
+++ b/native/src/linux/pulse_capture.cpp
@@ -29,6 +29,7 @@
 #include <fstream>
 #include <sstream>
 #include <algorithm>
+#include <utility>
 
 namespace haven {
 
@@ -115,6 +116,7 @@ struct SinkInputInfo {
     uint32_t    index;
     uint32_t    pid;
     uint32_t    sinkIndex;
+    uint32_t    ownerModule;
     std::string name;
 };
 
@@ -134,6 +136,7 @@ static void sinkInputCb(pa_context*, const pa_sink_input_info* info, int eol, vo
     SinkInputInfo si;
     si.index     = info->index;
     si.sinkIndex = info->sink;
+    si.ownerModule = info->owner_module;
     si.name      = info->name ? info->name : "Unknown";
 
     const char* pidStr = pa_proplist_gets(info->proplist, PA_PROP_APPLICATION_PROCESS_ID);
@@ -166,6 +169,83 @@ static void successCb(pa_context*, int success, void* ud) {
     auto* result = static_cast<OpDone*>(ud);
     result->success = success != 0;
     result->done = true;
+}
+
+static pa_buffer_attr lowLatencyRecordBuffer(const pa_sample_spec& spec) {
+    pa_buffer_attr attr;
+    attr.maxlength = static_cast<uint32_t>(pa_usec_to_bytes(100000, &spec));
+    attr.tlength = static_cast<uint32_t>(-1);
+    attr.prebuf = static_cast<uint32_t>(-1);
+    attr.minreq = static_cast<uint32_t>(-1);
+    attr.fragsize = static_cast<uint32_t>(pa_usec_to_bytes(10000, &spec));
+    return attr;
+}
+
+struct ServerSinkResult {
+    std::string name;
+    bool done = false;
+};
+
+static void serverSinkCb(pa_context*, const pa_server_info* info, void* ud) {
+    auto* result = static_cast<ServerSinkResult*>(ud);
+    if (info && info->default_sink_name) result->name = info->default_sink_name;
+    result->done = true;
+}
+
+static std::string defaultSinkName(PaSync& pa) {
+    ServerSinkResult result;
+    pa_operation* op = pa_context_get_server_info(pa.ctx, serverSinkCb, &result);
+    if (!op) return {};
+    while (!result.done) pa.iterateBlock();
+    pa_operation_unref(op);
+    return result.name;
+}
+
+struct NamedSinkResult {
+    std::string name;
+    uint32_t index = PA_INVALID_INDEX;
+    bool done = false;
+};
+
+static void namedSinkCb(pa_context*, const pa_sink_info* info, int eol, void* ud) {
+    auto* result = static_cast<NamedSinkResult*>(ud);
+    if (eol > 0 || !info) {
+        result->done = true;
+        return;
+    }
+    if (info->name && result->name == info->name) result->index = info->index;
+}
+
+static uint32_t sinkIndexByName(PaSync& pa, const std::string& name) {
+    NamedSinkResult result;
+    result.name = name;
+    pa_operation* op = pa_context_get_sink_info_by_name(pa.ctx, name.c_str(), namedSinkCb, &result);
+    if (!op) return PA_INVALID_INDEX;
+    while (!result.done) pa.iterateBlock();
+    pa_operation_unref(op);
+    return result.index;
+}
+
+static bool moveSinkInput(PaSync& pa, uint32_t inputIndex, uint32_t sinkIndex) {
+    OpDone result;
+    pa_operation* op = pa_context_move_sink_input_by_index(
+        pa.ctx, inputIndex, sinkIndex, successCb, &result);
+    if (!op) return false;
+    while (!result.done) pa.iterateBlock();
+    pa_operation_unref(op);
+    return result.success;
+}
+
+static bool unloadModule(PaSync& pa, uint32_t& moduleIndex) {
+    if (moduleIndex == PA_INVALID_INDEX) return true;
+    OpDone result;
+    pa_operation* op = pa_context_unload_module(pa.ctx, moduleIndex, successCb, &result);
+    if (!op) return false;
+    while (!result.done) pa.iterateBlock();
+    pa_operation_unref(op);
+    if (!result.success) return false;
+    moduleIndex = PA_INVALID_INDEX;
+    return true;
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -240,8 +320,11 @@ std::vector<AudioApp> PulseCapture::GetAudioApplications() {
 }
 
 bool PulseCapture::StartCapture(uint32_t pid, CaptureMode mode,
-                                AudioDataCb dataCb, CaptureStatusCb statusCb) {
+                                 AudioDataCb dataCb, CaptureStatusCb statusCb) {
     StopCapture();
+    if (m_nullSinkModule != PA_INVALID_INDEX || m_loopbackModule != PA_INVALID_INDEX) {
+        return false;
+    }
 
     {
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -252,23 +335,15 @@ bool PulseCapture::StartCapture(uint32_t pid, CaptureMode mode,
         m_running        = true;
     }
 
+    std::string startingMessage;
     if (mode == CaptureMode::ExcludeProcess) {
-        // PulseAudio/PipeWire don't have a built-in equivalent to Windows'
-        // exclude-mode process loopback. Surface this clearly so the JS
-        // side can fall back to system-monitor capture explicitly.
-        emitStatus(CaptureStatusKind::Failed,
-            "Exclude-mode capture is not supported on Linux (PulseAudio/PipeWire)", 0);
-        m_running = false;
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_callback = nullptr;
-        m_statusCallback = nullptr;
-        return false;
+        startingMessage = "preparing system capture without PID tree " + std::to_string(pid);
+    } else if (mode == CaptureMode::SystemLoopback) {
+        startingMessage = "preparing pulse system capture";
+    } else {
+        startingMessage = "preparing pulse capture for PID " + std::to_string(pid);
     }
-
-    emitStatus(CaptureStatusKind::Starting,
-        mode == CaptureMode::SystemLoopback
-            ? "preparing pulse system capture"
-            : "preparing pulse capture for PID " + std::to_string(pid));
+    emitStatus(CaptureStatusKind::Starting, startingMessage);
 
     m_thread = std::thread([this]() { captureLoop(); });
     return true;
@@ -283,22 +358,16 @@ void PulseCapture::StopCapture() {
     }
 
     // Clean up PulseAudio modules
-    if (m_nullSinkModule != 0 || m_loopbackModule != 0) {
+    if (m_nullSinkModule != PA_INVALID_INDEX || m_loopbackModule != PA_INVALID_INDEX) {
         PaSync pa;
         if (pa.connect()) {
-            if (m_loopbackModule != 0) {
-                OpDone od;
-                auto* op = pa_context_unload_module(pa.ctx, m_loopbackModule, successCb, &od);
-                if (op) { while (!od.done) pa.iterateBlock(); pa_operation_unref(op); }
-            }
-            if (m_nullSinkModule != 0) {
-                OpDone od;
-                auto* op = pa_context_unload_module(pa.ctx, m_nullSinkModule, successCb, &od);
-                if (op) { while (!od.done) pa.iterateBlock(); pa_operation_unref(op); }
-            }
+            if (!unloadModule(pa, m_loopbackModule))
+                fprintf(stderr, "[Haven Pulse] failed to unload routing module\n");
+            if (!unloadModule(pa, m_nullSinkModule))
+                fprintf(stderr, "[Haven Pulse] failed to unload capture module\n");
+        } else {
+            fprintf(stderr, "[Haven Pulse] cleanup deferred: server unavailable\n");
         }
-        m_nullSinkModule = 0;
-        m_loopbackModule = 0;
     }
     if (wasRunning) emitStatus(CaptureStatusKind::Stopped, "pulse capture stopped");
     {
@@ -315,6 +384,159 @@ void PulseCapture::captureLoop() {
         emitStatus(CaptureStatusKind::Failed,
             "pa_context_connect failed (PulseAudio/PipeWire daemon not reachable)");
         m_running = false;
+        return;
+    }
+
+    if (m_mode == CaptureMode::ExcludeProcess) {
+        const std::string outputName = defaultSinkName(pa);
+        const uint32_t outputIndex = sinkIndexByName(pa, outputName);
+        if (outputName.empty() || outputIndex == PA_INVALID_INDEX) {
+            emitStatus(CaptureStatusKind::Failed, "PulseAudio has no default output");
+            m_running = false;
+            return;
+        }
+
+        const std::string suffix = std::to_string(getpid());
+        const std::string captureSinkName = "HavenCapture_" + suffix;
+        const std::string combinedSinkName = "HavenCombined_" + suffix;
+
+        ModuleLoadResult nullResult;
+        std::string nullArgs = "sink_name=" + captureSinkName +
+            " sink_properties=device.description=\"Haven\\ Clean\\ System\\ Capture\"" +
+            " rate=48000 channels=1 format=float32le";
+        pa_operation* op = pa_context_load_module(
+            pa.ctx, "module-null-sink", nullArgs.c_str(), moduleLoadCb, &nullResult);
+        if (op) {
+            while (!nullResult.done) pa.iterateBlock();
+            pa_operation_unref(op);
+        }
+        if (nullResult.index == PA_INVALID_INDEX) {
+            emitStatus(CaptureStatusKind::Failed, "PulseAudio could not create the clean capture output");
+            m_running = false;
+            return;
+        }
+        m_nullSinkModule = nullResult.index;
+
+        ModuleLoadResult combinedResult;
+        std::string combinedArgs = "sink_name=" + combinedSinkName +
+            " sink_properties=device.description=\"Haven\\ System\\ Without\\ Haven\"" +
+            " slaves=" + outputName + "," + captureSinkName + " adjust_time=0";
+        op = pa_context_load_module(
+            pa.ctx, "module-combine-sink", combinedArgs.c_str(), moduleLoadCb, &combinedResult);
+        if (op) {
+            while (!combinedResult.done) pa.iterateBlock();
+            pa_operation_unref(op);
+        }
+        if (combinedResult.index == PA_INVALID_INDEX) {
+            unloadModule(pa, m_nullSinkModule);
+            emitStatus(CaptureStatusKind::Failed,
+                "PipeWire could not create the clean system audio route");
+            m_running = false;
+            return;
+        }
+        m_loopbackModule = combinedResult.index;
+
+        usleep(50000);
+        const uint32_t captureSinkIndex = sinkIndexByName(pa, captureSinkName);
+        const uint32_t combinedSinkIndex = sinkIndexByName(pa, combinedSinkName);
+        if (captureSinkIndex == PA_INVALID_INDEX || combinedSinkIndex == PA_INVALID_INDEX) {
+            unloadModule(pa, m_loopbackModule);
+            unloadModule(pa, m_nullSinkModule);
+            emitStatus(CaptureStatusKind::Failed,
+                "PipeWire could not activate the clean system audio route");
+            m_running = false;
+            return;
+        }
+
+        std::vector<std::pair<uint32_t, uint32_t>> movedInputs;
+        auto routeNewInputs = [&]() {
+            SinkInputEnumData inputs;
+            pa_operation* listOp = pa_context_get_sink_input_info_list(
+                pa.ctx, sinkInputCb, &inputs);
+            if (!listOp) return;
+            while (!inputs.done) pa.iterateBlock();
+            pa_operation_unref(listOp);
+
+            for (const auto& input : inputs.inputs) {
+                if (input.ownerModule != PA_INVALID_INDEX || input.pid == 0 ||
+                    input.sinkIndex != outputIndex) continue;
+                if (isProcessInTree(input.pid, m_targetPid)) continue;
+                const bool alreadyMoved = std::any_of(
+                    movedInputs.begin(), movedInputs.end(),
+                    [&](const auto& moved) { return moved.first == input.index; });
+                if (alreadyMoved) continue;
+                if (moveSinkInput(pa, input.index, combinedSinkIndex)) {
+                    movedInputs.emplace_back(input.index, input.sinkIndex);
+                }
+            }
+        };
+        auto restoreWith = [&](PaSync& context) {
+            bool restored = true;
+            for (const auto& moved : movedInputs) {
+                if (!moveSinkInput(context, moved.first, moved.second)) restored = false;
+            }
+            return restored;
+        };
+        auto restoreInputs = [&]() {
+            if (restoreWith(pa)) return true;
+            PaSync retry;
+            return retry.connect() && restoreWith(retry);
+        };
+
+        routeNewInputs();
+
+        pa_sample_spec ss = { PA_SAMPLE_FLOAT32LE, 48000, 1 };
+        const pa_buffer_attr bufferAttr = lowLatencyRecordBuffer(ss);
+        const std::string monitorName = captureSinkName + ".monitor";
+        int err = 0;
+        pa_simple* rec = pa_simple_new(
+            nullptr, "HavenDesktop", PA_STREAM_RECORD,
+            monitorName.c_str(), "System Audio Without Haven",
+            &ss, nullptr, &bufferAttr, &err
+        );
+        if (!rec) {
+            if (!restoreInputs())
+                fprintf(stderr, "[Haven Pulse] failed to restore one or more audio streams\n");
+            unloadModule(pa, m_loopbackModule);
+            unloadModule(pa, m_nullSinkModule);
+            emitStatus(CaptureStatusKind::Failed,
+                std::string("pa_simple_new failed: ") + pa_strerror(err), err);
+            m_running = false;
+            return;
+        }
+
+        emitStatus(CaptureStatusKind::Started, "system capture active without Haven audio");
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_callback) {
+                std::vector<float> silence(480, 0.0f);
+                m_callback(silence.data(), silence.size());
+            }
+        }
+
+        const size_t chunkFrames = 480;
+        std::vector<float> buf(chunkFrames);
+        unsigned int chunksSinceRouteScan = 0;
+        while (m_running) {
+            if (pa_simple_read(rec, buf.data(), chunkFrames * sizeof(float), &err) < 0) {
+                emitStatus(CaptureStatusKind::Failed,
+                    std::string("PulseAudio clean system capture failed: ") + pa_strerror(err), err);
+                m_running = false;
+                break;
+            }
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                if (m_callback) m_callback(buf.data(), chunkFrames);
+            }
+            if (++chunksSinceRouteScan >= 25) {
+                routeNewInputs();
+                chunksSinceRouteScan = 0;
+            }
+        }
+
+        pa_simple_free(rec);
+        if (!restoreInputs())
+            fprintf(stderr, "[Haven Pulse] failed to restore one or more audio streams\n");
         return;
     }
 
@@ -345,11 +567,12 @@ void PulseCapture::captureLoop() {
 
         const std::string monitor = sink.name + ".monitor";
         pa_sample_spec ss = { PA_SAMPLE_FLOAT32LE, 48000, 1 };
+        const pa_buffer_attr bufferAttr = lowLatencyRecordBuffer(ss);
         int err = 0;
         pa_simple* rec = pa_simple_new(
             nullptr, "HavenDesktop", PA_STREAM_RECORD,
             monitor.c_str(), "System Audio Capture",
-            &ss, nullptr, nullptr, &err
+            &ss, nullptr, &bufferAttr, &err
         );
         if (!rec) {
             emitStatus(CaptureStatusKind::Failed,
@@ -470,11 +693,7 @@ void PulseCapture::captureLoop() {
     if (op) { while (!sl.done) pa.iterateBlock(); pa_operation_unref(op); }
 
     if (sl.idx == PA_INVALID_INDEX) {
-        // Cleanup and bail
-        OpDone od;
-        op = pa_context_unload_module(pa.ctx, m_nullSinkModule, successCb, &od);
-        if (op) { while (!od.done) pa.iterateBlock(); pa_operation_unref(op); }
-        m_nullSinkModule = 0;
+        unloadModule(pa, m_nullSinkModule);
         emitStatus(CaptureStatusKind::Failed, "PulseAudio could not find the capture output");
         m_running = false;
         return;
@@ -493,10 +712,7 @@ void PulseCapture::captureLoop() {
     if (op) { while (!origSinkLookup.done) pa.iterateBlock(); pa_operation_unref(op); }
 
     if (isPipeWire && origSinkLookup.name.empty()) {
-        OpDone od;
-        op = pa_context_unload_module(pa.ctx, m_nullSinkModule, successCb, &od);
-        if (op) { while (!od.done) pa.iterateBlock(); pa_operation_unref(op); }
-        m_nullSinkModule = 0;
+        unloadModule(pa, m_nullSinkModule);
         emitStatus(CaptureStatusKind::Failed,
             "PipeWire could not identify the selected application's output");
         m_running = false;
@@ -558,18 +774,8 @@ void PulseCapture::captureLoop() {
             // Never fall back to the output monitor here: that would turn an
             // application-only choice into a capture of every app, including
             // Haven voice output.
-            if (m_loopbackModule != 0) {
-                OpDone od2;
-                auto* unOp = pa_context_unload_module(pa.ctx, m_loopbackModule, successCb, &od2);
-                if (unOp) { while (!od2.done) pa.iterateBlock(); pa_operation_unref(unOp); }
-                m_loopbackModule = 0;
-            }
-            if (m_nullSinkModule != 0) {
-                OpDone od2;
-                auto* unOp = pa_context_unload_module(pa.ctx, m_nullSinkModule, successCb, &od2);
-                if (unOp) { while (!od2.done) pa.iterateBlock(); pa_operation_unref(unOp); }
-                m_nullSinkModule = 0;
-            }
+            unloadModule(pa, m_loopbackModule);
+            unloadModule(pa, m_nullSinkModule);
             emitStatus(CaptureStatusKind::Failed,
                 "PipeWire could not isolate the selected application audio");
             m_running = false;
@@ -582,10 +788,7 @@ void PulseCapture::captureLoop() {
             op = pa_context_move_sink_input_by_index(pa.ctx, targetSinkInput, sl.idx, successCb, &od);
             if (op) { while (!od.done) pa.iterateBlock(); pa_operation_unref(op); }
             if (!od.success) {
-                OpDone unload;
-                op = pa_context_unload_module(pa.ctx, m_nullSinkModule, successCb, &unload);
-                if (op) { while (!unload.done) pa.iterateBlock(); pa_operation_unref(op); }
-                m_nullSinkModule = 0;
+                unloadModule(pa, m_nullSinkModule);
                 emitStatus(CaptureStatusKind::Failed,
                     "PulseAudio could not isolate the selected application audio");
                 m_running = false;
@@ -612,36 +815,25 @@ void PulseCapture::captureLoop() {
     ss.format   = PA_SAMPLE_FLOAT32LE;
     ss.rate     = 48000;
     ss.channels = 1;
+    const pa_buffer_attr bufferAttr = lowLatencyRecordBuffer(ss);
 
     int err = 0;
     pa_simple* rec = pa_simple_new(
         nullptr, "HavenDesktop", PA_STREAM_RECORD,
         "HavenCapture.monitor", "Per-App Capture",
-        &ss, nullptr, nullptr, &err
+        &ss, nullptr, &bufferAttr, &err
     );
 
     if (!rec) {
         emitStatus(CaptureStatusKind::Failed,
             std::string("pa_simple_new failed: ") + pa_strerror(err), err);
         // Clean up modules before returning
-        if (m_loopbackModule != 0) {
-            OpDone od;
-            auto* unOp = pa_context_unload_module(pa.ctx, m_loopbackModule, successCb, &od);
-            if (unOp) { while (!od.done) pa.iterateBlock(); pa_operation_unref(unOp); }
-            m_loopbackModule = 0;
-        }
-        if (m_nullSinkModule != 0) {
-            OpDone od;
-            auto* unOp = pa_context_unload_module(pa.ctx, m_nullSinkModule, successCb, &od);
-            if (unOp) { while (!od.done) pa.iterateBlock(); pa_operation_unref(unOp); }
-            m_nullSinkModule = 0;
-        }
+        unloadModule(pa, m_loopbackModule);
+        unloadModule(pa, m_nullSinkModule);
         // Restore original sink
-        if (originalSink != PA_INVALID_INDEX) {
-            OpDone od;
-            auto* mvOp = pa_context_move_sink_input_by_index(pa.ctx, targetSinkInput, originalSink, successCb, &od);
-            if (mvOp) { while (!od.done) pa.iterateBlock(); pa_operation_unref(mvOp); }
-        }
+        if (originalSink != PA_INVALID_INDEX &&
+            !moveSinkInput(pa, targetSinkInput, originalSink))
+            fprintf(stderr, "[Haven Pulse] failed to restore application output\n");
         m_running = false;
         return;
     }
@@ -677,11 +869,9 @@ void PulseCapture::captureLoop() {
     {
         PaSync pa2;
         if (pa2.connect()) {
-            if (originalSink != PA_INVALID_INDEX) {
-                OpDone od;
-                op = pa_context_move_sink_input_by_index(pa2.ctx, targetSinkInput, originalSink, successCb, &od);
-                if (op) { while (!od.done) pa2.iterateBlock(); pa_operation_unref(op); }
-            }
+            if (originalSink != PA_INVALID_INDEX &&
+                !moveSinkInput(pa2, targetSinkInput, originalSink))
+                fprintf(stderr, "[Haven Pulse] failed to restore application output\n");
         }
     }
     // Module cleanup happens in StopCapture()

--- a/native/src/linux/pulse_capture.h
+++ b/native/src/linux/pulse_capture.h
@@ -50,8 +50,8 @@ private:
     uint32_t          m_targetPid = 0;
     CaptureMode       m_mode = CaptureMode::IncludeProcess;
     std::mutex        m_mutex;
-    uint32_t          m_nullSinkModule = 0;  // PulseAudio module index
-    uint32_t          m_loopbackModule = 0;  // loopback module index
+    uint32_t          m_nullSinkModule = UINT32_MAX; // PulseAudio module index
+    uint32_t          m_loopbackModule = UINT32_MAX; // loopback/combine module index
 };
 
 } // namespace haven

--- a/native/src/unsupported_capture.cpp
+++ b/native/src/unsupported_capture.cpp
@@ -1,0 +1,30 @@
+#if !defined(PLATFORM_WINDOWS) && !defined(PLATFORM_LINUX)
+
+#include "audio_capture.h"
+
+namespace haven {
+
+class UnsupportedCapture final : public IAudioCapture {
+public:
+    bool IsSupported() const override { return false; }
+    std::vector<AudioApp> GetAudioApplications() override { return {}; }
+
+    bool StartCapture(uint32_t, CaptureMode, AudioDataCb, CaptureStatusCb statusCb) override {
+        if (statusCb) {
+            statusCb({ CaptureStatusKind::Failed,
+                       "Per-application audio capture is unavailable on this platform", 0 });
+        }
+        return false;
+    }
+
+    void StopCapture() override {}
+    void Cleanup() override {}
+};
+
+IAudioCapture* CreateAudioCapture() {
+    return new UnsupportedCapture();
+}
+
+} // namespace haven
+
+#endif

--- a/native/src/win/wasapi_capture.cpp
+++ b/native/src/win/wasapi_capture.cpp
@@ -37,6 +37,7 @@
 #include <cstring>
 #include <algorithm>
 #include <chrono>
+#include <unordered_map>
 
 #pragma comment(lib, "ole32.lib")
 #pragma comment(lib, "mmdevapi.lib")
@@ -70,6 +71,33 @@ static std::string ProcessNameFromPid(DWORD pid) {
     }
     CloseHandle(h);
     return "Unknown";
+}
+
+static std::unordered_map<DWORD, DWORD> SnapshotProcessParents() {
+    std::unordered_map<DWORD, DWORD> parents;
+    HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (snapshot == INVALID_HANDLE_VALUE) return parents;
+
+    PROCESSENTRY32W entry = {};
+    entry.dwSize = sizeof(entry);
+    if (Process32FirstW(snapshot, &entry)) {
+        do {
+            parents[entry.th32ProcessID] = entry.th32ParentProcessID;
+        } while (Process32NextW(snapshot, &entry));
+    }
+    CloseHandle(snapshot);
+    return parents;
+}
+
+static bool IsProcessInTree(DWORD pid, DWORD rootPid,
+                            const std::unordered_map<DWORD, DWORD>& parents) {
+    for (size_t depth = 0; pid != 0 && depth <= parents.size(); depth++) {
+        if (pid == rootPid) return true;
+        auto it = parents.find(pid);
+        if (it == parents.end() || it->second == pid) break;
+        pid = it->second;
+    }
+    return false;
 }
 
 // ── Completion handler for ActivateAudioInterfaceAsync ────
@@ -182,6 +210,7 @@ std::vector<AudioApp> WasapiCapture::GetAudioApplications() {
     // Track PIDs we've already seen across all endpoints (avoid duplicates)
     std::vector<DWORD> seen;
     DWORD ourPid = GetCurrentProcessId();
+    const auto processParents = SnapshotProcessParents();
 
     IMMDeviceEnumerator* enumerator = nullptr;
     HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr,
@@ -232,7 +261,7 @@ std::vector<AudioApp> WasapiCapture::GetAudioApplications() {
 
             DWORD pid = 0;
             ctrl2->GetProcessId(&pid);
-            if (pid == 0 || pid == ourPid ||
+            if (pid == 0 || IsProcessInTree(pid, ourPid, processParents) ||
                 std::find(seen.begin(), seen.end(), pid) != seen.end()) {
                 ctrl2->Release(); ctrl->Release(); continue;
             }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "start": "electron .",
     "dev": "electron . --dev",
+    "test": "node --test test/*.test.js",
     "build": "npm run build:native && electron-builder",
     "build:win": "npm run build:native && electron-builder --win",
     "build:linux": "npm run build:native && electron-builder --linux",

--- a/src/main/app-preload.js
+++ b/src/main/app-preload.js
@@ -12,6 +12,7 @@
 // ═══════════════════════════════════════════════════════════
 
 const { ipcRenderer } = require('electron');
+const { BoundedPcmRing, shouldDropAudioPacket } = require('./screen-share-audio');
 
 // Mark the document as running inside the Electron shell.
 // This lets CSS override responsive breakpoints that would otherwise
@@ -448,6 +449,7 @@ let _activeShareId       = null;
 let _pendingShareId      = null;
 let _displayMediaPending = false;
 let _audioBufferQueue    = [];
+let _audioBufferedSamples = 0;
 let _audioPacketsReceived = 0;
 // ─── Global voice shortcut triggers ──────────────────────
 ipcRenderer.on('voice:mute-toggle',   () => document.getElementById('voice-mute-btn')?.click());
@@ -514,6 +516,7 @@ ipcRenderer.on('audio:share-mode', (_event, modeInfo) => {
 });
 ipcRenderer.on('audio:capture-data', (_event, payload) => {
   if (!payload?.captureId || payload.captureId !== _activeAudioCaptureId) return;
+  if (shouldDropAudioPacket(payload.capturedAt)) return;
   const pcmData = payload.data;
   // Build a Float32Array from whatever Electron's IPC delivers.
   // The main process now sends a plain ArrayBuffer (guaranteed offset-0),
@@ -547,11 +550,16 @@ ipcRenderer.on('audio:capture-data', (_event, payload) => {
   }
 
   if (_audioWorkletNode) {
-    _audioWorkletNode.port.postMessage({ type: 'audio-data', samples });
+    _audioWorkletNode.port.postMessage({ type: 'audio-data', samples }, [samples.buffer]);
   } else if (window._havenAppAudioPush) {
     window._havenAppAudioPush(samples);
   } else {
-    _audioBufferQueue.push(samples);
+    const buffered = samples.length > 4800 ? samples.subarray(samples.length - 4800) : samples;
+    _audioBufferQueue.push(buffered);
+    _audioBufferedSamples += buffered.length;
+    while (_audioBufferedSamples > 4800 && _audioBufferQueue.length > 1) {
+      _audioBufferedSamples -= _audioBufferQueue.shift().length;
+    }
   }
   _audioPacketsReceived++;
 });
@@ -579,7 +587,7 @@ function getScreenPickerCopy() {
       windows: 'Janelas',
       audio: 'Áudio',
       noAudio: 'Sem áudio',
-      systemAudio: 'Todo o áudio do sistema',
+      systemAudio: 'Áudio do sistema sem o Haven',
       applicationAudio: 'Áudio de um aplicativo',
       noApplications: 'Nenhum aplicativo reproduzindo áudio',
       systemUnavailable: 'Áudio do sistema indisponível',
@@ -597,7 +605,7 @@ function getScreenPickerCopy() {
     windows: 'Windows',
     audio: 'Audio',
     noAudio: 'No audio',
-    systemAudio: 'All system audio',
+    systemAudio: 'System audio without Haven',
     applicationAudio: 'Audio from one application',
     noApplications: 'No applications are playing audio',
     systemUnavailable: 'System audio unavailable',
@@ -875,32 +883,26 @@ async function buildAudioPipeline() {
   _audioPacketsReceived = 0;
   _ipcDataCount = 0;
   _audioBufferQueue = [];
+  _audioBufferedSamples = 0;
 
   // Try AudioWorklet first, fall back to ScriptProcessorNode if it fails
   // (AudioWorklet blob URLs can fail in some Electron/BrowserView contexts)
   try {
-    _audioCtx = new AudioContext({ sampleRate: 48000 });
+    _audioCtx = new AudioContext({ sampleRate: 48000, latencyHint: 'interactive' });
     // Explicitly resume — BrowserView contexts may start suspended
     if (_audioCtx.state === 'suspended') await _audioCtx.resume();
 
     // Inline AudioWorklet processor (blob URL avoids CSP / file issues)
     const workletSrc = `
+      ${BoundedPcmRing.toString()}
       class AppAudioProcessor extends AudioWorkletProcessor {
         constructor() {
           super();
-          this._ring   = new Float32Array(96000);   // 2 s ring buffer
-          this._wPos   = 0;
-          this._rPos   = 0;
-          this._avail  = 0;
+          this._ring = new BoundedPcmRing(4800); // Never retain more than 100 ms.
 
           this.port.onmessage = (e) => {
             if (e.data.type !== 'audio-data') return;
-            const s = e.data.samples;
-            for (let i = 0; i < s.length; i++) {
-              this._ring[this._wPos] = s[i];
-              this._wPos = (this._wPos + 1) % this._ring.length;
-            }
-            this._avail = Math.min(this._avail + s.length, this._ring.length);
+            this._ring.push(e.data.samples);
           };
         }
 
@@ -910,13 +912,7 @@ async function buildAudioPipeline() {
           const buf = out[0];
           const len = buf.length;
 
-          if (this._avail < len) { buf.fill(0); return true; }
-
-          for (let i = 0; i < len; i++) {
-            buf[i] = this._ring[this._rPos];
-            this._rPos = (this._rPos + 1) % this._ring.length;
-          }
-          this._avail -= len;
+          this._ring.pull(buf);
 
           for (let ch = 1; ch < out.length; ch++) out[ch].set(buf);
           return true;
@@ -947,9 +943,10 @@ async function buildAudioPipeline() {
 
     // Flush any PCM that arrived before the pipeline was ready
     _audioBufferQueue.forEach(buf =>
-      _audioWorkletNode.port.postMessage({ type: 'audio-data', samples: buf })
+      _audioWorkletNode.port.postMessage({ type: 'audio-data', samples: buf }, [buf.buffer])
     );
     _audioBufferQueue = [];
+    _audioBufferedSamples = 0;
 
     // Expose track globally so our getDisplayMedia override can grab it
     window._havenAppAudioTrack  = _audioDestination.stream.getAudioTracks()[0];
@@ -975,47 +972,34 @@ async function buildAudioPipeline() {
 
   // ── Fallback: ScriptProcessorNode (works in all Electron versions) ──
   try {
-    _audioCtx = new AudioContext({ sampleRate: 48000 });
+    _audioCtx = new AudioContext({ sampleRate: 48000, latencyHint: 'interactive' });
     if (_audioCtx.state === 'suspended') await _audioCtx.resume();
 
-    const bufSize = 4096;
+    const bufSize = 1024;
     // Use 1 input channel (not 0).  A "generator" ScriptProcessor with
     // 0 inputs may not have its onaudioprocess callback pumped reliably
     // in Electron / BrowserView environments.  Connecting a live source
     // to the input guarantees Chromium's audio thread drives the node.
     const scriptNode = _audioCtx.createScriptProcessor(bufSize, 1, 2);
-    const ring   = new Float32Array(96000);
-    let   wPos   = 0;
-    let   rPos   = 0;
-    let   avail  = 0;
+    const ring = new BoundedPcmRing(4800);
     let   _spProcessCount = 0;
 
     // Store a push function that the IPC handler can call
     window._havenAppAudioPush = (samples) => {
-      for (let i = 0; i < samples.length; i++) {
-        ring[wPos] = samples[i];
-        wPos = (wPos + 1) % ring.length;
-      }
-      avail = Math.min(avail + samples.length, ring.length);
+      ring.push(samples);
     };
 
     scriptNode.onaudioprocess = (e) => {
       _spProcessCount++;
       const out = e.outputBuffer.getChannelData(0);
-      if (avail < out.length) { out.fill(0); } else {
-        for (let i = 0; i < out.length; i++) {
-          out[i] = ring[rPos];
-          rPos = (rPos + 1) % ring.length;
-        }
-        avail -= out.length;
-      }
+      ring.pull(out);
       // Copy mono to stereo
       const out1 = e.outputBuffer.getChannelData(1);
       out1.set(out);
       // Periodic diagnostic
       if (_spProcessCount === 1 || _spProcessCount % 200 === 0) {
         const peak = Math.max(...Array.from(out.slice(0, 128)).map(Math.abs));
-        console.log(`[Haven Desktop] ScriptProcessor process #${_spProcessCount}, avail=${avail}, peak=${peak.toFixed(4)}`);
+        console.log(`[Haven Desktop] ScriptProcessor process #${_spProcessCount}, avail=${ring.available}, peak=${peak.toFixed(4)}`);
       }
     };
 
@@ -1038,6 +1022,7 @@ async function buildAudioPipeline() {
     // Flush buffered PCM
     _audioBufferQueue.forEach(buf => window._havenAppAudioPush(buf));
     _audioBufferQueue = [];
+    _audioBufferedSamples = 0;
 
     window._havenAppAudioTrack  = _audioDestination.stream.getAudioTracks()[0];
     window._havenAppAudioStream = _audioDestination.stream;
@@ -1078,6 +1063,7 @@ function teardownAudioPipeline(captureId = _activeAudioCaptureId) {
   _capturedAudioPid = null;
   _activeAudioCaptureId = null;
   _audioBufferQueue = [];
+  _audioBufferedSamples = 0;
   _audioPacketsReceived = 0;
   _ipcDataCount     = 0;
   window._havenAppAudioTrack  = null;
@@ -1143,7 +1129,7 @@ function installGetDisplayMediaOverride() {
       // application-capture failure stays silent instead of exposing all audio.
       if (capturedAudioPid) {
         const timeoutMs = 8000;
-        const stepMs    = 100;
+        const stepMs    = 20;
         const start     = Date.now();
         let lastLog     = 0;
         while ((Date.now() - start) < timeoutMs) {

--- a/src/main/app-preload.js
+++ b/src/main/app-preload.js
@@ -443,6 +443,10 @@ let _audioWorkletNode    = null;
 let _audioCtx            = null;
 let _audioDestination    = null;
 let _capturedAudioPid    = null;
+let _activeAudioCaptureId = null;
+let _activeShareId       = null;
+let _pendingShareId      = null;
+let _displayMediaPending = false;
 let _audioBufferQueue    = [];
 let _audioPacketsReceived = 0;
 // ─── Global voice shortcut triggers ──────────────────────
@@ -491,22 +495,26 @@ let _ipcDataCount = 0;
 // instead of always burning the full timeout.
 let _lastNativeStatus = null;
 ipcRenderer.on('audio:capture-status', (_event, status) => {
+  if (!status?.captureId || status.captureId !== _activeAudioCaptureId) return;
   _lastNativeStatus = status;
   const codeHex = '0x' + ((status?.code || 0) >>> 0).toString(16);
   console.log(`[Haven Desktop] native capture status: kind=${status?.kind} code=${codeHex} msg=${status?.message}`);
 });
 
 // Resolved share-audio mode reported by main once the picker handler decides
-// what audio path to use (per-app / system-clean / fallback / loopback / none).
+// what audio path to use (application / system / none).
 // Forwarded to the page so the webapp can show a small mode indicator.
 ipcRenderer.on('audio:share-mode', (_event, modeInfo) => {
+  if (modeInfo?.captureId && modeInfo.captureId !== _activeShareId) return;
   console.log('[Haven Desktop] share audio mode:', modeInfo);
   try {
     window.__havenShareAudioMode = modeInfo;
     window.dispatchEvent(new CustomEvent('haven:share-audio-mode', { detail: modeInfo }));
   } catch (e) { console.warn('[Haven Desktop] dispatch share-mode event failed:', e.message); }
 });
-ipcRenderer.on('audio:capture-data', (_event, pcmData) => {
+ipcRenderer.on('audio:capture-data', (_event, payload) => {
+  if (!payload?.captureId || payload.captureId !== _activeAudioCaptureId) return;
+  const pcmData = payload.data;
   // Build a Float32Array from whatever Electron's IPC delivers.
   // The main process now sends a plain ArrayBuffer (guaranteed offset-0),
   // but we still handle typed-array arrivals defensively.
@@ -550,40 +558,93 @@ ipcRenderer.on('audio:capture-data', (_event, pcmData) => {
 
 // ─── Listen for screen-picker request from main process ──
 ipcRenderer.on('screen:show-picker', (_event, data) => {
-  showScreenPicker(data?.sources || [], data?.audioApps || [], data?.requestId || null);
+  showScreenPicker(
+    data?.sources || [],
+    data?.audioApps || [],
+    data?.audioCapabilities || {},
+    data?.requestId || null
+  );
 });
 
 // ═══════════════════════════════════════════════════════════
 // Screen-Share Picker  (injected as a full-screen overlay)
 // ═══════════════════════════════════════════════════════════
 
-function showScreenPicker(sources, audioApps, requestId) {
-  // Remove stale picker
-  document.getElementById('haven-screen-picker')?.remove();
+function getScreenPickerCopy() {
+  const language = (document.documentElement?.lang || navigator.language || 'en').toLowerCase();
+  if (language.startsWith('pt')) {
+    return {
+      title: 'Compartilhar tela',
+      screens: 'Telas',
+      windows: 'Janelas',
+      audio: 'Áudio',
+      noAudio: 'Sem áudio',
+      systemAudio: 'Todo o áudio do sistema',
+      applicationAudio: 'Áudio de um aplicativo',
+      noApplications: 'Nenhum aplicativo reproduzindo áudio',
+      systemUnavailable: 'Áudio do sistema indisponível',
+      applicationUnavailable: 'Áudio de aplicativos indisponível',
+      silent: 'silencioso',
+      silentDescription: 'A captura começa quando o aplicativo reproduzir áudio.',
+      noPreview: 'Sem prévia',
+      cancel: 'Cancelar',
+      share: 'Compartilhar',
+    };
+  }
+  return {
+    title: 'Share screen',
+    screens: 'Screens',
+    windows: 'Windows',
+    audio: 'Audio',
+    noAudio: 'No audio',
+    systemAudio: 'All system audio',
+    applicationAudio: 'Audio from one application',
+    noApplications: 'No applications are playing audio',
+    systemUnavailable: 'System audio unavailable',
+    applicationUnavailable: 'Application audio unavailable',
+    silent: 'silent',
+    silentDescription: 'Capture starts when the application plays audio.',
+    noPreview: 'No preview',
+    cancel: 'Cancel',
+    share: 'Share',
+  };
+}
 
+function showScreenPicker(sources, audioApps, audioCapabilities, requestId) {
+  const stalePicker = document.getElementById('haven-screen-picker');
+  const staleRequestId = stalePicker?.dataset.requestId;
+  if (staleRequestId && staleRequestId !== requestId) {
+    ipcRenderer.send('screen:picker-result', { requestId: staleRequestId, cancelled: true });
+  }
+  stalePicker?.remove();
+
+  const copy = getScreenPickerCopy();
+  const canShareSystemAudio = audioCapabilities.system === true;
+  const canShareApplicationAudio = audioCapabilities.application === true;
   const overlay = document.createElement('div');
   overlay.id = 'haven-screen-picker';
+  overlay.dataset.requestId = requestId;
   overlay.innerHTML = `
     <style>
       #haven-screen-picker {
         position:fixed;inset:0;background:rgba(0,0,0,.88);z-index:999999;
-        display:flex;align-items:center;justify-content:center;
+        display:flex;align-items:center;justify-content:center;padding:18px;box-sizing:border-box;
         font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
       }
-      .hsp-box{background:#1a1a2e;border-radius:14px;padding:28px;max-width:820px;width:92%;
-        max-height:82vh;display:flex;flex-direction:column;border:1px solid rgba(107,79,219,.3);
+      .hsp-box{background:#1a1a2e;border-radius:14px;padding:24px;max-width:900px;width:100%;
+        max-height:calc(100vh - 36px);box-sizing:border-box;display:flex;flex-direction:column;
+        border:1px solid rgba(107,79,219,.3);
         box-shadow:0 20px 60px rgba(0,0,0,.5);}
-      .hsp-title{color:#e0e0e0;font-size:20px;font-weight:700;margin-bottom:2px;flex-shrink:0}
-      .hsp-sub{color:#888;font-size:13px;margin-bottom:14px;flex-shrink:0}
-      .hsp-scroll{flex:1;overflow-y:auto;padding-right:4px;margin-right:-4px;min-height:0}
-      .hsp-sec{margin-bottom:14px}
+      .hsp-title{color:#f1f1f5;font-size:20px;font-weight:700;margin-bottom:18px;flex-shrink:0}
+      .hsp-scroll{flex:1;overflow-y:auto;padding-right:6px;margin-right:-6px;min-height:0}
+      .hsp-sec{margin-bottom:18px}
       .hsp-sec-title{color:#aaa;font-size:11px;text-transform:uppercase;letter-spacing:1.2px;
         margin-bottom:8px;font-weight:700}
       .hsp-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(175px,1fr));gap:10px}
-      .hsp-src{background:#16213e;border-radius:8px;padding:8px;cursor:pointer;
-        border:2px solid transparent;transition:border-color .2s,transform .15s}
+      .hsp-src{appearance:none;background:#16213e;border-radius:8px;padding:8px;cursor:pointer;
+        border:2px solid transparent;transition:border-color .2s,transform .15s;font:inherit;text-align:inherit}
       .hsp-src:hover{border-color:rgba(107,79,219,.5);transform:translateY(-1px)}
-      .hsp-src.sel{border-color:#6b4fdb}
+      .hsp-src.sel,.hsp-src:focus-visible{border-color:#8069e8;outline:none}
       .hsp-src img{width:100%;border-radius:4px;margin-bottom:6px;aspect-ratio:16/9;
         object-fit:cover;background:#0d0d1a}
       .hsp-src .hsp-thumb-ph{width:100%;border-radius:4px;margin-bottom:6px;aspect-ratio:16/9;
@@ -591,123 +652,166 @@ function showScreenPicker(sources, audioApps, requestId) {
         justify-content:center;color:#777;font-size:11px;letter-spacing:.3px}
       .hsp-src-name{color:#ccc;font-size:12px;text-align:center;white-space:nowrap;
         overflow:hidden;text-overflow:ellipsis}
-      .hsp-audio{padding-top:14px;border-top:1px solid #2a2a4a;flex-shrink:0;margin-top:10px}
+      .hsp-audio{padding-top:18px;border-top:1px solid #2a2a4a}
+      .hsp-app-title{color:#888;font-size:12px;margin:14px 0 8px}
       .hsp-apps{display:flex;flex-wrap:wrap;gap:8px}
-      .hsp-app{background:#16213e;border-radius:6px;padding:8px 14px;cursor:pointer;
+      .hsp-app{appearance:none;background:#16213e;border-radius:7px;padding:9px 14px;cursor:pointer;
         border:2px solid transparent;transition:border-color .2s;display:flex;
-        align-items:center;gap:8px;color:#ccc;font-size:13px}
+        align-items:center;gap:8px;color:#ccc;font:inherit;font-size:13px;text-align:left}
       .hsp-app:hover{border-color:rgba(107,79,219,.5)}
-      .hsp-app.sel{border-color:#6b4fdb}
+      .hsp-app.sel,.hsp-app:focus-visible{border-color:#8069e8;outline:none}
       .hsp-app .ico{width:20px;height:20px}
+      .hsp-empty{color:#777;font-size:12px;padding:4px 0}
       .hsp-btns{display:flex;justify-content:flex-end;gap:10px;margin-top:16px;flex-shrink:0}
       .hsp-btn{padding:8px 22px;border-radius:6px;border:none;font-size:14px;cursor:pointer;font-weight:600}
       .hsp-cancel{background:#333;color:#ccc}.hsp-cancel:hover{background:#444}
       .hsp-share{background:#6b4fdb;color:#fff}.hsp-share:hover{background:#7b5fe9}
       .hsp-share:disabled{opacity:.45;cursor:not-allowed}
-      .hsp-none{color:#666;font-size:12px;font-style:italic;padding:8px}
+      @media (max-width:600px){
+        #haven-screen-picker{padding:10px}.hsp-box{padding:18px;max-height:calc(100vh - 20px)}
+        .hsp-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.hsp-btn{flex:1}
+      }
     </style>
 
-    <div class="hsp-box">
-      <div class="hsp-title">Share Your Screen</div>
-      <div class="hsp-sub">Choose a window or screen — then optionally pick an application whose audio to share.</div>
+    <div class="hsp-box" role="dialog" aria-modal="true" aria-labelledby="hsp-title">
+      <div class="hsp-title" id="hsp-title">${copy.title}</div>
 
       <div class="hsp-scroll">
-        <div class="hsp-sec">
-          <div class="hsp-sec-title">Screens</div>
+        <div class="hsp-sec" id="hsp-screens-section">
+          <div class="hsp-sec-title">${copy.screens}</div>
           <div class="hsp-grid" id="hsp-screens"></div>
         </div>
 
-        <div class="hsp-sec">
-          <div class="hsp-sec-title">Application Windows</div>
+        <div class="hsp-sec" id="hsp-windows-section">
+          <div class="hsp-sec-title">${copy.windows}</div>
           <div class="hsp-grid" id="hsp-windows"></div>
+        </div>
+
+        <div class="hsp-audio">
+          <div class="hsp-sec-title">${copy.audio}</div>
+          <div class="hsp-apps" id="hsp-audio-modes"></div>
+          <div class="hsp-app-title">${copy.applicationAudio}</div>
+          <div class="hsp-apps" id="hsp-audio-apps"></div>
         </div>
       </div>
 
-      <div class="hsp-audio">
-        <div class="hsp-sec-title">🔊 Application Audio — isolate audio from a specific app</div>
-        <div class="hsp-apps" id="hsp-audio-apps"></div>
-      </div>
-
       <div class="hsp-btns">
-        <button class="hsp-btn hsp-cancel" id="hsp-cancel">Cancel</button>
-        <button class="hsp-btn hsp-share"  id="hsp-go" disabled>Share</button>
+        <button class="hsp-btn hsp-cancel" id="hsp-cancel" type="button">${copy.cancel}</button>
+        <button class="hsp-btn hsp-share" id="hsp-go" type="button" disabled>${copy.share}</button>
       </div>
     </div>`;
 
   document.body.appendChild(overlay);
 
   let selSource = null;
-  let selAudioPid = null;
+  let selAudioPid = 'none';
 
   const screensEl  = document.getElementById('hsp-screens');
   const windowsEl  = document.getElementById('hsp-windows');
+  const modesEl    = document.getElementById('hsp-audio-modes');
   const appsEl     = document.getElementById('hsp-audio-apps');
   const goBtn      = document.getElementById('hsp-go');
 
   // ── Populate video sources ─────────────────────────────
   sources.forEach(src => {
-    const el = document.createElement('div');
+    const el = document.createElement('button');
+    el.type = 'button';
     el.className = 'hsp-src';
-    const preview = src.thumbnail
-      ? `<img src="${src.thumbnail}" alt="">`
-      : `<div class="hsp-thumb-ph">No preview</div>`;
-    el.innerHTML = `${preview}<div class="hsp-src-name" title="${src.name}">${src.name}</div>`;
+    el.setAttribute('aria-pressed', 'false');
+    if (src.thumbnail) {
+      const preview = document.createElement('img');
+      preview.src = src.thumbnail;
+      preview.alt = '';
+      el.appendChild(preview);
+    } else {
+      const preview = document.createElement('div');
+      preview.className = 'hsp-thumb-ph';
+      preview.textContent = copy.noPreview;
+      el.appendChild(preview);
+    }
+    const sourceName = document.createElement('div');
+    sourceName.className = 'hsp-src-name';
+    sourceName.title = src.name;
+    sourceName.textContent = src.name;
+    el.appendChild(sourceName);
     el.onclick = () => {
-      overlay.querySelectorAll('.hsp-src.sel').forEach(s => s.classList.remove('sel'));
+      overlay.querySelectorAll('.hsp-src.sel').forEach(source => {
+        source.classList.remove('sel');
+        source.setAttribute('aria-pressed', 'false');
+      });
       el.classList.add('sel');
+      el.setAttribute('aria-pressed', 'true');
       selSource = src.id;
       goBtn.disabled = false;
     };
     (src.id.startsWith('screen:') ? screensEl : windowsEl).appendChild(el);
   });
+  if (!screensEl.children.length) document.getElementById('hsp-screens-section').hidden = true;
+  if (!windowsEl.children.length) document.getElementById('hsp-windows-section').hidden = true;
 
-  // ── Populate audio applications ────────────────────────
-  // "No Audio" option — always shown first
-  const muteEl = document.createElement('div');
-  muteEl.className = 'hsp-app';
-  muteEl.innerHTML = '🔇&nbsp; No Audio';
-  muteEl.onclick = () => {
-    appsEl.querySelectorAll('.sel').forEach(a => a.classList.remove('sel'));
-    muteEl.classList.add('sel');
-    selAudioPid = 'none';
+  const selectAudio = (element, value) => {
+    overlay.querySelectorAll('.hsp-app.sel').forEach(option => {
+      option.classList.remove('sel');
+      option.setAttribute('aria-pressed', 'false');
+    });
+    element.classList.add('sel');
+    element.setAttribute('aria-pressed', 'true');
+    selAudioPid = value;
   };
-  appsEl.appendChild(muteEl);
 
-  // "System Audio (no Haven voice)" — selected by default. On Windows we
-  // capture system audio via WASAPI exclude-mode so Haven's own voice output
-  // is filtered out. On Linux we fall back to Electron loopback (still
-  // includes Haven voice; can't be helped without OS-level support yet).
-  const sysEl = document.createElement('div');
-  sysEl.className = 'hsp-app sel';
-  sysEl.innerHTML = '🔊&nbsp; System Audio';
-  selAudioPid = 'system';
-  sysEl.onclick = () => {
-    appsEl.querySelectorAll('.sel').forEach(a => a.classList.remove('sel'));
-    sysEl.classList.add('sel');
-    selAudioPid = 'system';
+  const createAudioOption = (label, icon, value, selected = false) => {
+    const element = document.createElement('button');
+    element.type = 'button';
+    element.className = `hsp-app${selected ? ' sel' : ''}`;
+    element.setAttribute('aria-pressed', selected ? 'true' : 'false');
+    element.appendChild(document.createTextNode(`${icon} ${label}`));
+    element.onclick = () => selectAudio(element, value);
+    return element;
   };
-  appsEl.appendChild(sysEl);
 
-  // Per-app entries when native module is available. Inactive sessions
-  // (paused YouTube tabs, idle games) are shown but visually dimmed.
-  if (audioApps && audioApps.length) {
+  modesEl.appendChild(createAudioOption(copy.noAudio, '🔇', 'none', true));
+  if (canShareSystemAudio) {
+    modesEl.appendChild(createAudioOption(copy.systemAudio, '🔊', 'system'));
+  } else {
+    const unavailable = document.createElement('div');
+    unavailable.className = 'hsp-empty';
+    unavailable.textContent = copy.systemUnavailable;
+    modesEl.appendChild(unavailable);
+  }
+
+  if (canShareApplicationAudio && audioApps.length) {
     audioApps.forEach(a => {
-      const el = document.createElement('div');
+      const el = document.createElement('button');
+      el.type = 'button';
       el.className = 'hsp-app';
+      el.setAttribute('aria-pressed', 'false');
       if (a.active === false) el.style.opacity = '0.55';
-      const icon = a.icon ? `<img class="ico" src="${a.icon}" alt="">` : '🔊';
-      const dim  = a.active === false ? ' <span style="color:#888;font-size:11px">(silent)</span>' : '';
-      el.innerHTML = `${icon}<span>${a.name}${dim}</span>`;
+      if (a.icon) {
+        const icon = document.createElement('img');
+        icon.className = 'ico';
+        icon.src = a.icon;
+        icon.alt = '';
+        el.appendChild(icon);
+      } else {
+        el.appendChild(document.createTextNode('🔊'));
+      }
+      const name = document.createElement('span');
+      name.textContent = a.name;
+      if (a.active === false) name.appendChild(document.createTextNode(` (${copy.silent})`));
+      el.appendChild(name);
       el.title = a.active === false
-        ? 'This app is currently silent. Capture will start as soon as it produces audio.'
+        ? copy.silentDescription
         : a.name;
-      el.onclick = () => {
-        appsEl.querySelectorAll('.sel').forEach(x => x.classList.remove('sel'));
-        el.classList.add('sel');
-        selAudioPid = a.pid;
-      };
+      el.onclick = () => selectAudio(el, a.pid);
       appsEl.appendChild(el);
     });
+  } else {
+    const empty = document.createElement('div');
+    empty.className = 'hsp-empty';
+    empty.textContent = canShareApplicationAudio
+      ? copy.noApplications
+      : copy.applicationUnavailable;
+    appsEl.appendChild(empty);
   }
 
   // ── Cancel ─────────────────────────────────────────────
@@ -722,24 +826,26 @@ function showScreenPicker(sources, audioApps, requestId) {
     try { document.body?.focus(); window.focus(); } catch {}
 
     let effectiveAudioPid = selAudioPid;
-    // Native pipeline applies to per-app PIDs AND to 'system' (which uses
-    // WASAPI exclude-mode in main to strip Haven's voice from the share).
-    const wantsNativePipeline = !cancelled && selAudioPid &&
-                                selAudioPid !== 'none';
-    if (wantsNativePipeline) {
+    if (!cancelled) {
+      teardownAudioPipeline(_activeAudioCaptureId);
+      _activeShareId = requestId;
+    }
+
+    const wantsNativePipeline = (Number.isSafeInteger(selAudioPid) && selAudioPid > 0)
+      || (selAudioPid === 'system' && audioCapabilities.systemNative === true);
+    if (!cancelled && wantsNativePipeline) {
+      _activeAudioCaptureId = requestId;
       _capturedAudioPid = selAudioPid;
       console.log(`[Haven Desktop] Picker dismissed: building native audio pipeline for ${selAudioPid}`);
       const pipelineOk = await buildAudioPipeline();
       if (!pipelineOk) {
-        console.warn('[Haven Desktop] Local audio pipeline failed to build — main will fall back to Electron loopback for system audio, or silence for per-app');
-        _capturedAudioPid = null;
-        // For per-app picks, leave effectiveAudioPid alone — main will see
-        // the request and try to start native capture; if that ALSO fails
-        // it stays silent. For 'system' picks, leave it as 'system' too —
-        // main will try exclude-mode and last-ditch fall back to loopback.
+        console.warn('[Haven Desktop] Local audio pipeline failed to build; continuing without audio');
+        teardownAudioPipeline(requestId);
+        effectiveAudioPid = 'none';
       }
     }
 
+    _pendingShareId = requestId;
     ipcRenderer.send('screen:picker-result', cancelled
       ? { requestId, cancelled: true }
       : { requestId, sourceId: selSource, audioAppPid: effectiveAudioPid });
@@ -956,9 +1062,10 @@ async function buildAudioPipeline() {
   }
 }
 
-function teardownAudioPipeline() {
+function teardownAudioPipeline(captureId = _activeAudioCaptureId) {
+  if (captureId && captureId !== _activeAudioCaptureId) return;
   // Stop native capture first so IPC messages stop arriving
-  ipcRenderer.invoke('audio:stop-capture').catch(() => {});
+  if (captureId) ipcRenderer.invoke('audio:stop-capture', { captureId }).catch(() => {});
   if (window._havenAudioCtxMonitor) {
     clearInterval(window._havenAudioCtxMonitor);
     window._havenAudioCtxMonitor = null;
@@ -969,6 +1076,7 @@ function teardownAudioPipeline() {
   _audioCtx         = null;
   _audioDestination = null;
   _capturedAudioPid = null;
+  _activeAudioCaptureId = null;
   _audioBufferQueue = [];
   _audioPacketsReceived = 0;
   _ipcDataCount     = 0;
@@ -1001,80 +1109,96 @@ function installGetDisplayMediaOverride() {
   const _origGDM = navigator.mediaDevices.getDisplayMedia.bind(navigator.mediaDevices);
 
   navigator.mediaDevices.getDisplayMedia = async function (constraints) {
+    if (_displayMediaPending) {
+      throw new DOMException('A screen-share request is already open.', 'InvalidStateError');
+    }
+    _displayMediaPending = true;
+
     // Reset native status before each share so a stale "failed" from a
     // prior session doesn't poison the next attempt.
     _lastNativeStatus = null;
 
-    const stream = await _origGDM(constraints);
-    const audioTracksFromElectron = stream.getAudioTracks().length;
-    console.log(`[Haven Desktop] getDisplayMedia resolved (capturedAudioPid=${_capturedAudioPid}, electron-audio-tracks=${audioTracksFromElectron}, per-app track ready=${!!window._havenAppAudioTrack})`);
-
-    // If a native capture was requested (per-app PID OR 'system' exclude-mode),
-    // wait for the first PCM packet to land.  IF AND ONLY IF native PCM
-    // arrives, we strip Electron's loopback track and substitute the per-app
-    // PCM track.  If PCM never arrives we leave Electron's loopback track in
-    // place so the share has *some* audio \u2014 silent shares are the worse UX
-    // (per user feedback after the per-app overhaul: many Windows installs
-    // hit ActivateAudioInterfaceAsync E_INVALIDARG / E_NOT_IMPLEMENTED on
-    // the WASAPI Process Loopback API, leaving every share dead-silent).
-    if (_capturedAudioPid) {
-      const timeoutMs = 8000;
-      const stepMs    = 100;
-      const start     = Date.now();
-      let lastLog     = 0;
-      while ((Date.now() - start) < timeoutMs) {
-        if (_audioPacketsReceived > 0) break;
-        // Abort early on hard failure from native side.
-        if (_lastNativeStatus && _lastNativeStatus.kind === 'failed') {
-          console.warn(`[Haven Desktop] native capture reported FAILED during readiness wait — keeping Electron loopback so share isn't silent`);
-          break;
-        }
-        if (Date.now() - lastLog > 1000) {
-          lastLog = Date.now();
-          console.log(`[Haven Desktop] waiting for first PCM packet... elapsed=${Date.now() - start}ms received=${_audioPacketsReceived} status=${_lastNativeStatus?.kind || 'none'}`);
-        }
-        await new Promise(resolve => setTimeout(resolve, stepMs));
+    let stream;
+    try {
+      stream = await _origGDM(constraints);
+    } catch (error) {
+      const failedShareId = _pendingShareId;
+      _pendingShareId = null;
+      if (failedShareId && _activeShareId === failedShareId) {
+        teardownAudioPipeline(failedShareId);
+        _activeShareId = null;
       }
-
-      if (_audioPacketsReceived > 0 && window._havenAppAudioTrack) {
-        // Native pipeline succeeded — NOW it's safe to drop Electron's
-        // loopback and substitute the clean per-app / exclude-mode track.
-        stream.getAudioTracks().forEach(t => { try { stream.removeTrack(t); t.stop(); } catch {} });
-        stream.addTrack(window._havenAppAudioTrack);
-        console.log(`[Haven Desktop] per-app/system-exclude audio track added (waited ${Date.now() - start}ms, ${_audioPacketsReceived} PCM chunks received)`);
-      } else {
-        // Native capture failed.  KEEP Electron's loopback track so the
-        // share is audible.  Yes, this can include Haven's own voice
-        // output (echo risk) but silence is worse — the share-audio-mode
-        // badge / toast will already warn the user.
-        console.warn('[Haven Desktop] readiness wait expired without PCM. Diagnostics:');
-        console.warn('  capturedAudioPid:', _capturedAudioPid);
-        console.warn('  packetsReceived:', _audioPacketsReceived);
-        console.warn('  ipcDataCount:', _ipcDataCount);
-        console.warn('  havenAppAudioTrack present:', !!window._havenAppAudioTrack);
-        console.warn('  audioCtx state:', _audioCtx?.state);
-        console.warn('  audioWorkletNode present:', !!_audioWorkletNode);
-        console.warn('  havenAppAudioPush present:', !!window._havenAppAudioPush);
-        console.warn('  lastNativeStatus:', _lastNativeStatus);
-        console.warn("  Falling back to Electron loopback audio so share isn't silent (Haven voice loop possible).");
-      }
-    } else if (window._havenAppAudioTrack) {
-      // Defensive: a per-app track exists but no _capturedAudioPid was set.
-      // Prefer per-app over loopback to be safe.
-      stream.getAudioTracks().forEach(t => { try { stream.removeTrack(t); t.stop(); } catch {} });
-      stream.addTrack(window._havenAppAudioTrack);
-      console.log('[Haven Desktop] Added pre-existing per-app audio track to share (defensive)');
-    } else {
-      // No native capture requested. Whatever Electron returned (loopback or
-      // nothing) is what we use. If audio was requested via constraints but
-      // not delivered, that's an Electron-level issue, not ours.
-      console.log(`[Haven Desktop] no native capture requested; using Electron-provided audio (${audioTracksFromElectron} track(s))`);
+      _displayMediaPending = false;
+      throw error;
     }
+    try {
+      const shareId = _pendingShareId || _activeShareId;
+      _pendingShareId = null;
+      const captureId = shareId === _activeAudioCaptureId ? shareId : null;
+      const capturedAudioPid = captureId ? _capturedAudioPid : null;
+      const audioTracksFromElectron = stream.getAudioTracks().length;
+      console.log(`[Haven Desktop] getDisplayMedia resolved (capturedAudioPid=${capturedAudioPid}, electron-audio-tracks=${audioTracksFromElectron}, per-app track ready=${!!window._havenAppAudioTrack})`);
 
-    // Auto-teardown when the video track ends (user stops sharing)
-    stream.getVideoTracks().forEach(t => t.addEventListener('ended', () => teardownAudioPipeline()));
+      // Native capture is strict: wait for PCM and add only that track. An
+      // application-capture failure stays silent instead of exposing all audio.
+      if (capturedAudioPid) {
+        const timeoutMs = 8000;
+        const stepMs    = 100;
+        const start     = Date.now();
+        let lastLog     = 0;
+        while ((Date.now() - start) < timeoutMs) {
+          if (_activeAudioCaptureId !== captureId) break;
+          if (_audioPacketsReceived > 0) break;
+          if (_lastNativeStatus && _lastNativeStatus.kind === 'failed') {
+            console.warn('[Haven Desktop] native capture reported FAILED during readiness wait');
+            break;
+          }
+          if (Date.now() - lastLog > 1000) {
+            lastLog = Date.now();
+            console.log(`[Haven Desktop] waiting for first PCM packet... elapsed=${Date.now() - start}ms received=${_audioPacketsReceived} status=${_lastNativeStatus?.kind || 'none'}`);
+          }
+          await new Promise(resolve => setTimeout(resolve, stepMs));
+        }
 
-    return stream;
+        if (_activeAudioCaptureId === captureId &&
+            _audioPacketsReceived > 0 && window._havenAppAudioTrack) {
+          // Remove any unexpected Electron track before attaching native audio.
+          stream.getAudioTracks().forEach(t => { try { stream.removeTrack(t); t.stop(); } catch {} });
+          stream.addTrack(window._havenAppAudioTrack);
+          console.log(`[Haven Desktop] native audio track added (waited ${Date.now() - start}ms, ${_audioPacketsReceived} PCM chunks received)`);
+        } else {
+          console.warn('[Haven Desktop] readiness wait expired without PCM. Diagnostics:');
+          console.warn('  capturedAudioPid:', capturedAudioPid);
+          console.warn('  packetsReceived:', _audioPacketsReceived);
+          console.warn('  ipcDataCount:', _ipcDataCount);
+          console.warn('  havenAppAudioTrack present:', !!window._havenAppAudioTrack);
+          console.warn('  audioCtx state:', _audioCtx?.state);
+          console.warn('  audioWorkletNode present:', !!_audioWorkletNode);
+          console.warn('  havenAppAudioPush present:', !!window._havenAppAudioPush);
+          console.warn('  lastNativeStatus:', _lastNativeStatus);
+          console.warn('  Continuing without audio to prevent a Haven voice loop.');
+          stream.getAudioTracks().forEach(t => { try { stream.removeTrack(t); t.stop(); } catch {} });
+          teardownAudioPipeline(captureId);
+        }
+      } else if (window._havenAppAudioTrack && !_activeAudioCaptureId) {
+        // A track without an active selection is stale and must never leak into
+        // a later "no audio" or "all system audio" share.
+        teardownAudioPipeline();
+      } else {
+        console.log(`[Haven Desktop] no native capture requested; using Electron-provided audio (${audioTracksFromElectron} track(s))`);
+      }
+
+      // An older video track must not tear down a newer share.
+      stream.getVideoTracks().forEach(track => track.addEventListener('ended', () => {
+        if (_activeShareId !== shareId) return;
+        teardownAudioPipeline(captureId);
+        _activeShareId = null;
+      }));
+
+      return stream;
+    } finally {
+      _displayMediaPending = false;
+    }
   };
 
   console.log('[Haven Desktop] getDisplayMedia override installed');
@@ -1147,9 +1271,6 @@ window.havenDesktop = {
   },
 
   audio: {
-    getApplications: () => ipcRenderer.invoke('audio:get-apps'),
-    startCapture:    (pid) => ipcRenderer.invoke('audio:start-capture', pid),
-    stopCapture:     ()    => { teardownAudioPipeline(); return ipcRenderer.invoke('audio:stop-capture'); },
     isSupported:     ()    => ipcRenderer.invoke('audio:is-supported'),
     optOutOfDucking: ()    => ipcRenderer.invoke('audio:opt-out-ducking'),
   },

--- a/src/main/audio-capture.js
+++ b/src/main/audio-capture.js
@@ -13,8 +13,9 @@
 const path = require('path');
 
 class AudioCaptureManager {
-  constructor(addon = null) {
+  constructor(addon = null, beforeStop = null) {
     this._addon    = addon;
+    this._beforeStop = beforeStop;
     this._capturing = false;
     this._generation = 0;
     if (!this._addon) this._loadAddon();
@@ -148,6 +149,9 @@ class AudioCaptureManager {
   stopCapture() {
     clearTimeout(this._watchdog);
     this._generation++;
+    if (this._beforeStop) {
+      try { this._beforeStop(); } catch { /* */ }
+    }
     if (this._addon && this._capturing) {
       try { this._addon.stopCapture(); } catch { /* */ }
     }

--- a/src/main/audio-capture.js
+++ b/src/main/audio-capture.js
@@ -67,7 +67,7 @@ class AudioCaptureManager {
    * Start capturing audio.
    * @param {number} pid               Target process ID
    * @param {Object} opts              Capture options
-   * @param {'include'|'exclude'} [opts.mode='include']
+   * @param {'include'|'exclude'|'system'} [opts.mode='include']
    *                                   include: capture FROM this PID tree
    *                                   exclude: capture all system audio EXCEPT this PID tree
    *                                   (Windows only — Linux returns failure for exclude)
@@ -83,7 +83,10 @@ class AudioCaptureManager {
     if (typeof opts === 'function') {
       opts = { mode: 'include', onData: opts };
     }
-    const mode    = (opts && opts.mode) === 'exclude' ? 'exclude' : 'include';
+    const requestedMode = opts && opts.mode;
+    const mode = requestedMode === 'exclude' || requestedMode === 'system'
+      ? requestedMode
+      : 'include';
     const onData  = opts && opts.onData;
     const onStatus = opts && opts.onStatus;
     if (typeof onData !== 'function') throw new Error('startCapture: onData callback required');

--- a/src/main/audio-capture.js
+++ b/src/main/audio-capture.js
@@ -13,11 +13,11 @@
 const path = require('path');
 
 class AudioCaptureManager {
-  constructor() {
-    this._addon    = null;
+  constructor(addon = null) {
+    this._addon    = addon;
     this._capturing = false;
-    this._callback  = null;
-    this._loadAddon();
+    this._generation = 0;
+    if (!this._addon) this._loadAddon();
   }
 
   // ── Load the compiled native module ─────────────────────
@@ -70,8 +70,8 @@ class AudioCaptureManager {
    * @param {'include'|'exclude'|'system'} [opts.mode='include']
    *                                   include: capture FROM this PID tree
    *                                   exclude: capture all system audio EXCEPT this PID tree
-   *                                   (Windows only — Linux returns failure for exclude)
-   * @param {function} opts.onData     Receives Float32Array PCM chunks (48 kHz mono)
+   *                                   (native on Windows and Linux)
+   * @param {function} opts.onData     Receives (Float32Array, capturedAtMs) PCM chunks
    * @param {function} [opts.onStatus] Receives {kind, message, code} status events.
    *                                   kinds: 'starting' | 'started' | 'failed' | 'stopped'
    * @returns {boolean} true if synchronous activation succeeded
@@ -93,24 +93,25 @@ class AudioCaptureManager {
 
     if (this._capturing) this.stopCapture();
 
-    this._callback   = onData;
-    this._onStatus   = onStatus || null;
+    const generation = ++this._generation;
     this._capturing  = true;
     this._lastDataAt = Date.now();
     this._initFailed = false;
     this._lastStatus = null;
 
-    const dataWrap = (pcm) => {
+    const dataWrap = (pcm, capturedAt) => {
+      if (!this._capturing || this._generation !== generation) return;
       this._lastDataAt = Date.now();
-      if (this._callback) this._callback(pcm);
+      onData(pcm, capturedAt);
     };
 
     const statusWrap = (s) => {
+      if (!this._capturing || this._generation !== generation) return;
       this._lastStatus = s;
       if (s && s.kind === 'failed') this._initFailed = true;
       console.log(`[AudioCapture] native status: ${s?.kind} (code=0x${(s?.code >>> 0).toString(16)}) — ${s?.message}`);
-      if (this._onStatus) {
-        try { this._onStatus(s); } catch (e) { console.warn('[AudioCapture] onStatus threw:', e.message); }
+      if (onStatus) {
+        try { onStatus(s); } catch (e) { console.warn('[AudioCapture] onStatus threw:', e.message); }
       }
     };
 
@@ -118,7 +119,6 @@ class AudioCaptureManager {
       const ok = this._addon.startCapture(pid, mode, dataWrap, statusWrap);
       if (!ok) {
         this._capturing = false;
-        this._callback  = null;
         const reason = this._lastStatus?.message || 'native startCapture returned false';
         console.warn(`[AudioCapture] start failed (mode=${mode}, pid=${pid}): ${reason}`);
         return false;
@@ -130,7 +130,8 @@ class AudioCaptureManager {
       // Bumped from 8s because some sources (paused games) take a while to
       // produce real audio; the native heartbeat keeps lastDataAt fresh.
       this._watchdog = setTimeout(() => {
-        if (this._capturing && Date.now() - this._lastDataAt > 11000) {
+        if (this._capturing && this._generation === generation &&
+            Date.now() - this._lastDataAt > 11000) {
           console.warn('[AudioCapture] No data received in 11s — stopping capture');
           this.stopCapture();
         }
@@ -139,7 +140,6 @@ class AudioCaptureManager {
       return true;
     } catch (e) {
       this._capturing = false;
-      this._callback  = null;
       throw e;
     }
   }
@@ -147,11 +147,11 @@ class AudioCaptureManager {
   /** Stop active capture. */
   stopCapture() {
     clearTimeout(this._watchdog);
+    this._generation++;
     if (this._addon && this._capturing) {
       try { this._addon.stopCapture(); } catch { /* */ }
     }
     this._capturing = false;
-    this._callback  = null;
   }
 
   /**

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1930,10 +1930,12 @@ function registerScreenShareHandler() {
       catch (err) { console.warn('[ScreenShare] audio app enumeration failed:', err.message); }
 
       const nativeAudioAvailable = audioCapture.isSupported();
+      const nativeSystemAudio = nativeAudioAvailable &&
+        (process.platform === 'win32' || process.platform === 'linux');
       const audioCapabilities = {
         application: nativeAudioAvailable,
-        systemNative: process.platform === 'linux' && nativeAudioAvailable,
-        system: process.platform === 'win32' || (process.platform === 'linux' && nativeAudioAvailable),
+        systemNative: nativeSystemAudio,
+        system: nativeSystemAudio,
       };
 
       const sourceData = sources.map(s => ({
@@ -2034,7 +2036,7 @@ function registerScreenShareHandler() {
           console.log(`[ScreenShare] starting native capture: mode=${mode} pid=${pid}`);
           ok = audioCapture.startCapture(pid, {
             mode,
-            onData: (pcmData) => {
+            onData: (pcmData, capturedAt) => {
               try {
                 if (!pcmData || !pcmData.buffer) return;
                 const ab = pcmData.buffer.slice(
@@ -2042,7 +2044,11 @@ function registerScreenShareHandler() {
                   pcmData.byteOffset + pcmData.byteLength
                 );
                 if (!audioCaptureController.isActive(requestId)) return;
-                safeSend(targetContents, 'audio:capture-data', { captureId: requestId, data: ab });
+                safeSend(targetContents, 'audio:capture-data', {
+                  captureId: requestId,
+                  capturedAt,
+                  data: ab,
+                });
               } catch (cbErr) {
                 console.warn('[ScreenShare] audio callback error:', cbErr.message);
               }
@@ -2050,11 +2056,12 @@ function registerScreenShareHandler() {
             onStatus: (s) => {
               if (!audioCaptureController.isActive(requestId)) return;
               safeSend(targetContents, 'audio:capture-status', { ...s, captureId: requestId });
+              const isSystemMode = mode === 'exclude' || mode === 'system';
               if (s.kind === 'started') {
                 safeSend(targetContents, 'audio:share-mode', {
                   captureId: requestId,
-                  requested: mode === 'system' ? 'system' : 'app',
-                  applied: mode === 'system' ? 'system-loopback' : 'app',
+                  requested: isSystemMode ? 'system' : 'app',
+                  applied: isSystemMode ? 'system-clean' : 'app',
                   detail,
                 });
               } else if (s.kind === 'failed') {
@@ -2062,7 +2069,7 @@ function registerScreenShareHandler() {
                 audioCaptureController.clear(requestId);
                 safeSend(targetContents, 'audio:share-mode', {
                   captureId: requestId,
-                  requested: mode === 'system' ? 'system' : 'app',
+                  requested: isSystemMode ? 'system' : 'app',
                   applied: 'none',
                   detail: s.message || null,
                 });
@@ -2115,16 +2122,12 @@ function registerScreenShareHandler() {
         }
       } else if (audioSelection.type === 'system') {
         requestedMode = 'system';
-        if (audioCapabilities.systemNative) {
-          const capture = startNative('system', 0);
-          if (capture.ok) {
-            useNativeAudio = true;
-            appliedMode = 'system-loopback';
-          } else {
-            appliedDetail = `system capture failed: ${capture.reason || 'unknown reason'}`;
-          }
+        const capture = startNative('exclude', process.pid);
+        if (capture.ok) {
+          useNativeAudio = true;
+          appliedMode = 'system-clean';
         } else {
-          appliedMode = 'system-loopback';
+          appliedDetail = `system capture failed: ${capture.reason || 'unknown reason'}`;
         }
       }
 
@@ -2137,11 +2140,9 @@ function registerScreenShareHandler() {
         });
       }
 
-      if (appliedMode === 'system-loopback' && !useNativeAudio) {
-        safeCallback({ video: selected, audio: 'loopback' });
-      } else {
-        safeCallback({ video: selected });
-      }
+      // Native audio is attached by the preload only after the isolated track
+      // is ready. Never request raw Electron loopback, which includes Haven.
+      safeCallback({ video: selected });
 
     } catch (err) {
       console.error('[ScreenShare] handler error:', err);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -13,6 +13,10 @@ const os    = require('os');
 const Store = require('electron-store');
 const { ServerManager }      = require('./server-manager');
 const { AudioCaptureManager } = require('./audio-capture');
+const {
+  createAudioCaptureController,
+  resolveAudioSelection,
+} = require('./screen-share-audio');
 
 // ── Auto-Updater (electron-updater) ───────────────────────
 let autoUpdater;
@@ -134,6 +138,10 @@ let welcomeWindow   = null;
 let tray            = null;
 let serverManager   = null;
 let audioCapture    = null;
+const audioCaptureController = createAudioCaptureController(() => {
+  try { audioCapture?.stopCapture(); } catch {}
+});
+let screenShareRequestInProgress = false;
 let serverViews     = new Map();  // serverUrl → BrowserView
 let activeServerUrl = null;
 let primaryServerUrl = null;       // the server the user actually chose to connect to
@@ -1886,6 +1894,12 @@ function registerScreenShareHandler() {
       callback(payload);
     };
 
+    if (screenShareRequestInProgress) {
+      safeCallback({});
+      return;
+    }
+    screenShareRequestInProgress = true;
+
     try {
       // Video sources
       let sources;
@@ -1908,8 +1922,19 @@ function registerScreenShareHandler() {
 
       // Audio-producing applications (native addon)
       let audioApps = [];
-      try { audioApps = audioCapture.getAudioApplications(); }
+      try {
+        audioApps = audioCapture.getAudioApplications().filter(app =>
+          Number.isSafeInteger(app?.pid) && app.pid > 0 && app.pid !== process.pid
+        );
+      }
       catch (err) { console.warn('[ScreenShare] audio app enumeration failed:', err.message); }
+
+      const nativeAudioAvailable = audioCapture.isSupported();
+      const audioCapabilities = {
+        application: nativeAudioAvailable,
+        systemNative: process.platform === 'linux' && nativeAudioAvailable,
+        system: process.platform === 'win32' || (process.platform === 'linux' && nativeAudioAvailable),
+      };
 
       const sourceData = sources.map(s => ({
         id:         s.id,
@@ -1923,14 +1948,20 @@ function registerScreenShareHandler() {
       const requestFrame = request?.frame;
       const targetContents = requestFrame?.host || getActiveContents();
       if (!targetContents) { safeCallback({}); return; }
+      if (targetContents !== getActiveContents()) {
+        console.warn('[ScreenShare] rejected display capture outside the active Haven view');
+        safeCallback({});
+        return;
+      }
 
       const requestId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+      const pickerData = { requestId, sources: sourceData, audioApps, audioCapabilities };
 
       // Ask renderer to show the picker
       let sentToFrame = false;
       if (requestFrame && !requestFrame.isDestroyed()) {
         try {
-          requestFrame.send('screen:show-picker', { requestId, sources: sourceData, audioApps });
+          requestFrame.send('screen:show-picker', pickerData);
           sentToFrame = true;
           console.log('[ScreenShare] picker request sent to request.frame');
         } catch (err) {
@@ -1940,23 +1971,34 @@ function registerScreenShareHandler() {
       const frameHostId = requestFrame?.host?.id;
       const targetId = targetContents?.id;
       if (!sentToFrame || frameHostId !== targetId) {
-        safeSend(targetContents, 'screen:show-picker', { requestId, sources: sourceData, audioApps });
+        safeSend(targetContents, 'screen:show-picker', pickerData);
         console.log('[ScreenShare] picker request sent to target webContents fallback');
       }
 
       // Wait for picker result (or 60 s timeout)
       const result = await new Promise(resolve => {
-        const handler = (_e, res = {}) => {
-          if (res.requestId !== requestId) return;
+        let settled = false;
+        let timeoutId;
+        const finish = (value) => {
+          if (settled) return;
+          settled = true;
           clearTimeout(timeoutId);
           ipcMain.removeListener('screen:picker-result', handler);
-          resolve(res);
+          targetContents.removeListener('destroyed', ownerGone);
+          targetContents.removeListener('render-process-gone', ownerGone);
+          resolve(value);
         };
-        const timeoutId = setTimeout(() => {
-          ipcMain.removeListener('screen:picker-result', handler);
-          resolve({ cancelled: true, requestId });
-        }, 60000);
+        const handler = (event, res = {}) => {
+          if (event.sender.id !== targetContents.id) return;
+          if (res.requestId !== requestId) return;
+          finish(res);
+        };
+        const ownerGone = () => finish({ cancelled: true, requestId });
+        timeoutId = setTimeout(ownerGone, 60000);
         ipcMain.on('screen:picker-result', handler);
+        targetContents.once('destroyed', ownerGone);
+        targetContents.once('render-process-gone', ownerGone);
+        if (targetContents.isDestroyed()) ownerGone();
       });
 
       if (result.cancelled) { safeCallback({}); return; }
@@ -1972,17 +2014,22 @@ function registerScreenShareHandler() {
         console.log(`[ScreenShare] selected source ID changed between picker and attach: ${result.sourceId} -> ${selected.id} (${selected.name})`);
       }
 
-      // Decide capture path based on picker result.
-      //   audioAppPid > 0  → INCLUDE-mode capture of that PID
-      //   audioAppPid === 'system' → EXCLUDE-mode capture of OUR PID
-      //                       (= all system audio minus Haven; no voice loop)
-      //   audioAppPid === 'none'   → no audio at all
-      //   undefined         → legacy "system audio" via Electron loopback
-      //                       (still includes Haven voice — kept only as a
-      //                        last-resort path; UI now defaults to 'system')
-      const startNative = (mode, pid) => {
+      // Only PIDs included in this picker's enumeration may be captured.
+      // Unknown, stale, or forged values resolve to no audio.
+      const audioSelection = resolveAudioSelection(
+        result.audioAppPid,
+        audioApps,
+        audioCapabilities
+      );
+      const selectedAudioApp = audioSelection.app;
+      if (typeof result.audioAppPid === 'number' && !selectedAudioApp) {
+        console.warn(`[ScreenShare] rejected unlisted audio PID ${result.audioAppPid}`);
+      }
+
+      const startNative = (mode, pid, detail = null) => {
         const reasonRef = { msg: null };
         let ok = false;
+        audioCaptureController.start(requestId, targetContents);
         try {
           console.log(`[ScreenShare] starting native capture: mode=${mode} pid=${pid}`);
           ok = audioCapture.startCapture(pid, {
@@ -1994,103 +2041,113 @@ function registerScreenShareHandler() {
                   pcmData.byteOffset,
                   pcmData.byteOffset + pcmData.byteLength
                 );
-                safeSend(targetContents, 'audio:capture-data', ab);
+                if (!audioCaptureController.isActive(requestId)) return;
+                safeSend(targetContents, 'audio:capture-data', { captureId: requestId, data: ab });
               } catch (cbErr) {
                 console.warn('[ScreenShare] audio callback error:', cbErr.message);
               }
             },
             onStatus: (s) => {
-              safeSend(targetContents, 'audio:capture-status', s);
-              if (s.kind === 'failed') reasonRef.msg = s.message;
+              if (!audioCaptureController.isActive(requestId)) return;
+              safeSend(targetContents, 'audio:capture-status', { ...s, captureId: requestId });
+              if (s.kind === 'started') {
+                safeSend(targetContents, 'audio:share-mode', {
+                  captureId: requestId,
+                  requested: mode === 'system' ? 'system' : 'app',
+                  applied: mode === 'system' ? 'system-loopback' : 'app',
+                  detail,
+                });
+              } else if (s.kind === 'failed') {
+                reasonRef.msg = s.message;
+                audioCaptureController.clear(requestId);
+                safeSend(targetContents, 'audio:share-mode', {
+                  captureId: requestId,
+                  requested: mode === 'system' ? 'system' : 'app',
+                  applied: 'none',
+                  detail: s.message || null,
+                });
+                setImmediate(() => {
+                  if (!audioCaptureController.hasActive()) {
+                    try { audioCapture.stopCapture(); } catch {}
+                  }
+                });
+              }
             },
           });
         } catch (err) {
           console.error(`[ScreenShare] native capture (${mode}) threw:`, err.message);
           reasonRef.msg = err.message;
         }
+        if (!ok) {
+          const message = reasonRef.msg || 'Native audio capture could not start';
+          safeSend(targetContents, 'audio:capture-status', {
+            captureId: requestId,
+            kind: 'failed',
+            message,
+            code: 0,
+          });
+          audioCaptureController.stop(requestId, targetContents.id);
+        }
         return { ok, reason: reasonRef.msg };
       };
 
-      // What the user wanted, and what we ended up with.
-      // requestedMode: 'app' | 'system' | 'none' | 'legacy-loopback'
-      // appliedMode  : 'app' | 'system-clean' | 'fallback-system-clean'
-      //              | 'system-loopback' | 'none'
-      let requestedMode = 'legacy-loopback';
-      let appliedMode   = 'system-loopback';
+      // Audio choices are strict: application capture never degrades to full
+      // system loopback, which could feed Haven's own voice back into the call.
+      let requestedMode = 'none';
+      let appliedMode   = 'none';
       let appliedDetail = null; // optional human-readable string
+      let useNativeAudio = false;
 
-      let usePerAppAudio = false;
+      audioCaptureController.stop();
 
-      if (result.audioAppPid === 'none') {
-        requestedMode = 'none';
-        appliedMode   = 'none';
-      } else if (typeof result.audioAppPid === 'number' && result.audioAppPid > 0) {
+      if (selectedAudioApp) {
         requestedMode = 'app';
-        const appName = (audioApps.find(a => a.pid === result.audioAppPid) || {}).name || `pid ${result.audioAppPid}`;
-        const r1 = startNative('include', result.audioAppPid);
-        if (r1.ok) {
-          usePerAppAudio = true;
+        const appName = selectedAudioApp.name || `pid ${selectedAudioApp.pid}`;
+        const capture = startNative('include', selectedAudioApp.pid, appName);
+        if (capture.ok) {
+          useNativeAudio = true;
           appliedMode    = 'app';
           appliedDetail  = appName;
           console.log(`[ScreenShare] per-app capture active for "${appName}"`);
         } else {
-          // Per-app capture failed. Fall back to system-minus-Haven so the
-          // user gets *something* without creating a voice loop.
-          console.warn(`[ScreenShare] per-app capture failed (${r1.reason || 'unknown'}); falling back to system-minus-Haven`);
-          const r2 = startNative('exclude', process.pid);
-          if (r2.ok) {
-            usePerAppAudio = true;
-            appliedMode    = 'fallback-system-clean';
-            appliedDetail  = `app capture failed: ${r1.reason || 'unknown reason'}`;
-            console.log('[ScreenShare] fallback to system-minus-Haven active');
-          } else {
-            // Even exclude-mode failed. As a final last-resort, ask Electron
-            // for raw loopback (will include Haven voice — voice loop risk —
-            // but better than silence per user preference for per-app fail).
-            console.warn(`[ScreenShare] system-minus-Haven also failed (${r2.reason || 'unknown'}); using Electron loopback as last resort`);
-            appliedMode   = 'system-loopback';
-            appliedDetail = `native capture unavailable: ${r2.reason || r1.reason || 'unknown'}`;
-          }
+          appliedDetail = `app capture failed: ${capture.reason || 'unknown reason'}`;
+          console.warn(`[ScreenShare] per-app capture failed (${capture.reason || 'unknown'}); continuing without audio`);
         }
-      } else if (result.audioAppPid === 'system') {
+      } else if (audioSelection.type === 'system') {
         requestedMode = 'system';
-        const r = startNative('exclude', process.pid);
-        if (r.ok) {
-          usePerAppAudio = true;
-          appliedMode    = 'system-clean';
+        if (audioCapabilities.systemNative) {
+          const capture = startNative('system', 0);
+          if (capture.ok) {
+            useNativeAudio = true;
+            appliedMode = 'system-loopback';
+          } else {
+            appliedDetail = `system capture failed: ${capture.reason || 'unknown reason'}`;
+          }
         } else {
-          console.warn(`[ScreenShare] exclude-mode failed (${r.reason || 'unknown'}); using Electron loopback as fallback`);
-          appliedMode   = 'system-loopback';
-          appliedDetail = `clean system audio unavailable: ${r.reason || 'unknown'}`;
+          appliedMode = 'system-loopback';
         }
       }
 
-      // Tell the renderer which mode we ended up in (for the indicator)
-      safeSend(targetContents, 'audio:share-mode', {
-        requested: requestedMode,
-        applied:   appliedMode,
-        detail:    appliedDetail,
-      });
+      if (!useNativeAudio) {
+        safeSend(targetContents, 'audio:share-mode', {
+          captureId: requestId,
+          requested: requestedMode,
+          applied:   appliedMode,
+          detail:    appliedDetail,
+        });
+      }
 
-      // Audio routing for the share:
-      //   Native per-app / system-clean capture now takes the no-audio
-      //   callback path on purpose. We start the native pipeline first,
-      //   let getDisplayMedia() resolve with video only, and then the
-      //   renderer adds the native track once the first PCM arrives.
-      //   That avoids the old race where Electron loopback got attached
-      //   immediately, then the override had to guess whether it was safe
-      //   to strip / replace that track before native audio was actually
-      //   flowing. Only pure loopback fallback asks Electron for audio
-      //   up front; 'none' requests no audio at all. (#30)
-      if (appliedMode === 'none' || usePerAppAudio) {
-        safeCallback({ video: selected });
-      } else {
+      if (appliedMode === 'system-loopback' && !useNativeAudio) {
         safeCallback({ video: selected, audio: 'loopback' });
+      } else {
+        safeCallback({ video: selected });
       }
 
     } catch (err) {
       console.error('[ScreenShare] handler error:', err);
       safeCallback({});
+    } finally {
+      screenShareRequestInProgress = false;
     }
   });
 }
@@ -2140,23 +2197,10 @@ function registerIPC() {
   });
 
   // ── Audio Capture ─────────────────────────────────────
-  ipcMain.handle('audio:get-apps',      () => { try { return audioCapture.getAudioApplications(); } catch { return []; } });
-  ipcMain.handle('audio:start-capture',  (_e, pid) => {
-    try {
-      return audioCapture.startCapture(pid, {
-        mode: 'include',
-        onData: pcm => {
-          try {
-            if (!pcm || !pcm.buffer) return;
-            const ab = pcm.buffer.slice(pcm.byteOffset, pcm.byteOffset + pcm.byteLength);
-            safeSend(getActiveContents(), 'audio:capture-data', ab);
-          } catch { /* non-critical */ }
-        },
-        onStatus: s => safeSend(getActiveContents(), 'audio:capture-status', s),
-      });
-    } catch (e) { console.error('[AudioCapture] start-capture IPC failed:', e.message); return false; }
+  ipcMain.handle('audio:stop-capture', (event, { captureId } = {}) => {
+    if (typeof captureId !== 'string') return false;
+    return audioCaptureController.stop(captureId, event.sender.id);
   });
-  ipcMain.handle('audio:stop-capture',   () => { try { audioCapture.stopCapture(); } catch {} });
   ipcMain.handle('audio:is-supported',   () => { try { return audioCapture.isSupported(); } catch { return false; } });
   ipcMain.handle('audio:opt-out-ducking', () => audioCapture.optOutOfDucking());
 

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -13,6 +13,7 @@ const os    = require('os');
 const Store = require('electron-store');
 const { ServerManager }      = require('./server-manager');
 const { AudioCaptureManager } = require('./audio-capture');
+const { PipeWireStreamRouter } = require('./pipewire-stream-router');
 const {
   createAudioCaptureController,
   resolveAudioSelection,
@@ -138,6 +139,9 @@ let welcomeWindow   = null;
 let tray            = null;
 let serverManager   = null;
 let audioCapture    = null;
+const pipeWireStreamRouter = process.platform === 'linux'
+  ? new PipeWireStreamRouter()
+  : null;
 const audioCaptureController = createAudioCaptureController(() => {
   try { audioCapture?.stopCapture(); } catch {}
 });
@@ -295,7 +299,7 @@ app.on('ready', () => {
 
 app.whenReady().then(async () => {
   serverManager = new ServerManager(store, { showConsole: SHOW_SERVER || IS_DEV });
-  audioCapture  = new AudioCaptureManager();
+  audioCapture  = new AudioCaptureManager(null, () => pipeWireStreamRouter?.stop());
   badgeIcon     = createBadgeIcon();
 
   // ── Sync start-on-login with OS ──────────────────────
@@ -690,6 +694,7 @@ app.on('window-all-closed', () => {
 app.on('before-quit', () => {
   app.isQuitting = true;
   serverManager?.stopServer();
+  pipeWireStreamRouter?.stop();
   audioCapture?.cleanup();
 });
 
@@ -2058,6 +2063,9 @@ function registerScreenShareHandler() {
               safeSend(targetContents, 'audio:capture-status', { ...s, captureId: requestId });
               const isSystemMode = mode === 'exclude' || mode === 'system';
               if (s.kind === 'started') {
+                if (mode === 'exclude' && process.platform === 'linux') {
+                  pipeWireStreamRouter?.start(`HavenCombined_${process.pid}`, process.pid);
+                }
                 safeSend(targetContents, 'audio:share-mode', {
                   captureId: requestId,
                   requested: isSystemMode ? 'system' : 'app',
@@ -2065,6 +2073,7 @@ function registerScreenShareHandler() {
                   detail,
                 });
               } else if (s.kind === 'failed') {
+                pipeWireStreamRouter?.stop();
                 reasonRef.msg = s.message;
                 audioCaptureController.clear(requestId);
                 safeSend(targetContents, 'audio:share-mode', {

--- a/src/main/pipewire-stream-router.js
+++ b/src/main/pipewire-stream-router.js
@@ -1,0 +1,337 @@
+const fs = require('fs');
+const { spawn, spawnSync } = require('child_process');
+
+function createJsonArrayParser(onValue, onError = () => {}) {
+  let current = '';
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  return (chunk) => {
+    for (const char of chunk.toString()) {
+      if (depth === 0) {
+        if (char !== '[') continue;
+        current = char;
+        depth = 1;
+        inString = false;
+        escaped = false;
+        continue;
+      }
+
+      current += char;
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (char === '\\') {
+          escaped = true;
+        } else if (char === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (char === '"') {
+        inString = true;
+      } else if (char === '[' || char === '{') {
+        depth++;
+      } else if (char === ']' || char === '}') {
+        depth--;
+      }
+
+      if (depth !== 0) continue;
+      try {
+        onValue(JSON.parse(current));
+      } catch (err) {
+        onError(err);
+      }
+      current = '';
+    }
+  };
+}
+
+function processParentPid(pid, readFileSync = fs.readFileSync) {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+    const commandEnd = stat.lastIndexOf(')');
+    if (commandEnd < 0) return 0;
+    const fields = stat.slice(commandEnd + 2).trim().split(/\s+/);
+    const parent = Number(fields[1]);
+    return Number.isSafeInteger(parent) && parent > 0 ? parent : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function isProcessInTree(pid, rootPid, readFileSync = fs.readFileSync) {
+  if (!Number.isSafeInteger(pid) || pid <= 0 ||
+      !Number.isSafeInteger(rootPid) || rootPid <= 0) return false;
+
+  for (let depth = 0; pid > 0 && depth < 64; depth++) {
+    if (pid === rootPid) return true;
+    const parent = processParentPid(pid, readFileSync);
+    if (!parent || parent === pid) break;
+    pid = parent;
+  }
+  return false;
+}
+
+function metadataValue(value, type) {
+  if (typeof value === 'string') return value;
+  if (type === 'Spa:String:JSON') return JSON.stringify(value);
+  return String(value);
+}
+
+class PipeWireStreamRouter {
+  constructor({
+    spawnProcess = spawn,
+    runCommand = spawnSync,
+    processInTree = isProcessInTree,
+    logger = console,
+  } = {}) {
+    this._spawnProcess = spawnProcess;
+    this._runCommand = runCommand;
+    this._processInTree = processInTree;
+    this._logger = logger;
+    this._monitor = null;
+    this._objects = new Map();
+    this._metadataTargets = new Map();
+    this._routes = new Map();
+    this._routing = new Set();
+    this._warnedMetadata = false;
+  }
+
+  start(combinedSinkName, rootPid = process.pid) {
+    this.stop();
+    if (!combinedSinkName || !Number.isSafeInteger(rootPid) || rootPid <= 0) return false;
+
+    this._combinedSinkName = combinedSinkName;
+    this._rootPid = rootPid;
+
+    let monitor;
+    try {
+      monitor = this._spawnProcess(
+        'pw-dump',
+        ['--monitor', '--no-colors', '--indent=0'],
+        { stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true }
+      );
+    } catch (err) {
+      this._logger.warn(`[ScreenShare] PipeWire stream monitor unavailable: ${err.message}`);
+      return false;
+    }
+    if (!monitor?.stdout) return false;
+
+    this._monitor = monitor;
+    const parse = createJsonArrayParser(
+      batch => {
+        if (this._monitor === monitor) this._handleBatch(batch);
+      },
+      err => this._logger.warn(`[ScreenShare] Invalid pw-dump update: ${err.message}`)
+    );
+    monitor.stdout.on('data', parse);
+    monitor.once('error', (err) => {
+      if (this._monitor !== monitor) return;
+      this._logger.warn(`[ScreenShare] PipeWire stream monitor failed: ${err.message}`);
+      this.stop();
+    });
+    monitor.once('close', () => {
+      if (this._monitor !== monitor) return;
+      this._logger.warn('[ScreenShare] PipeWire stream monitor stopped unexpectedly');
+      this.stop();
+    });
+    return true;
+  }
+
+  stop() {
+    const monitor = this._monitor;
+    this._monitor = null;
+    if (monitor) {
+      try { monitor.kill(); } catch {}
+    }
+
+    const failedRoutes = [];
+    for (const [nodeId, route] of this._routes) {
+      if (!this._restoreRoute(nodeId, route) && !this._restoreRoute(nodeId, route)) {
+        failedRoutes.push(nodeId);
+      }
+    }
+    if (failedRoutes.length) {
+      this._logger.warn(
+        `[ScreenShare] Could not restore PipeWire stream route(s): ${failedRoutes.join(', ')}`
+      );
+    }
+    this._objects.clear();
+    this._metadataTargets.clear();
+    this._routes.clear();
+    this._routing.clear();
+    this._warnedMetadata = false;
+  }
+
+  _handleBatch(batch) {
+    if (!Array.isArray(batch)) return;
+
+    for (const update of batch) {
+      if (!Number.isSafeInteger(update?.id)) continue;
+      if (update.info === null) {
+        this._removeObject(update.id);
+        continue;
+      }
+      this._updateObject(update);
+    }
+    this._routeEligibleStreams();
+  }
+
+  _updateObject(update) {
+    const existing = this._objects.get(update.id);
+    const type = update.type || existing?.type;
+
+    if (type === 'PipeWire:Interface:Client' || type === 'PipeWire:Interface:Node') {
+      const props = {
+        ...(existing?.props || {}),
+        ...(update.info?.props || {}),
+      };
+      this._objects.set(update.id, { type, props });
+      return;
+    }
+
+    if (type === 'PipeWire:Interface:Link') {
+      this._objects.set(update.id, {
+        type,
+        outputNode: update.info?.['output-node-id'] ?? existing?.outputNode,
+        inputNode: update.info?.['input-node-id'] ?? existing?.inputNode,
+      });
+      return;
+    }
+
+    if (type !== 'PipeWire:Interface:Metadata') return;
+    const props = { ...(existing?.props || {}), ...(update.props || {}) };
+    this._objects.set(update.id, { type, props });
+    if (props['metadata.name'] !== 'default') return;
+
+    for (const entry of update.metadata || []) {
+      const subject = Number(entry.subject);
+      if (!Number.isSafeInteger(subject) || entry.key !== 'target.object') continue;
+      if (this._routes.has(subject) || this._routing.has(subject)) continue;
+      if (entry.value === null || entry.value === undefined) {
+        this._metadataTargets.delete(subject);
+      } else {
+        this._metadataTargets.set(subject, { type: entry.type, value: entry.value });
+      }
+    }
+  }
+
+  _removeObject(id) {
+    const route = this._routes.get(id);
+    if (route) {
+      this._runMetadata(['-n', 'default', '-d', String(id), 'target.object']);
+      this._routes.delete(id);
+    }
+    this._routing.delete(id);
+    this._metadataTargets.delete(id);
+    this._objects.delete(id);
+  }
+
+  _routeEligibleStreams() {
+    const combinedSink = [...this._objects.values()].find(object =>
+      object.type === 'PipeWire:Interface:Node' &&
+      object.props['node.name'] === this._combinedSinkName
+    );
+    const combinedSerial = Number(combinedSink?.props['object.serial']);
+    if (!Number.isSafeInteger(combinedSerial) || combinedSerial <= 0) return;
+
+    for (const [nodeId, node] of this._objects) {
+      if (node.type !== 'PipeWire:Interface:Node' ||
+          node.props['media.class'] !== 'Stream/Output/Audio' ||
+          this._routes.has(nodeId) || this._routing.has(nodeId)) continue;
+
+      const nodeName = String(node.props['node.name'] || '');
+      if (nodeName.startsWith(`output.${this._combinedSinkName}_`) ||
+          node.props['node.virtual'] === true) continue;
+
+      const clientId = Number(node.props['client.id']);
+      const client = this._objects.get(clientId);
+      const props = { ...(client?.props || {}), ...node.props };
+      if (props['client.api'] === 'pipewire-pulse' || this._isOwnStream(props)) continue;
+      if (!props['application.process.id'] && !props['application.name']) continue;
+
+      const originalSink = this._findLinkedSink(nodeId);
+      const originalSerial = Number(originalSink?.props['object.serial']);
+      if (!Number.isSafeInteger(originalSerial) || originalSerial <= 0 ||
+          originalSink.props['node.name'] === this._combinedSinkName) continue;
+
+      let previousTarget = this._metadataTargets.get(nodeId) || null;
+      if (Number(previousTarget?.value) === combinedSerial) previousTarget = null;
+      this._routing.add(nodeId);
+      const moved = this._runMetadata([
+        '-n', 'default', String(nodeId), 'target.object', String(combinedSerial), 'Spa:Id',
+      ]);
+      this._routing.delete(nodeId);
+      if (moved) this._routes.set(nodeId, { originalSerial, previousTarget });
+    }
+  }
+
+  _findLinkedSink(nodeId) {
+    for (const object of this._objects.values()) {
+      if (object.type !== 'PipeWire:Interface:Link' || object.outputNode !== nodeId) continue;
+      const target = this._objects.get(object.inputNode);
+      if (target?.type === 'PipeWire:Interface:Node') return target;
+    }
+    return null;
+  }
+
+  _isOwnStream(props) {
+    const access = String(props['pipewire.access.effective'] || props['pipewire.access'] || '');
+    const securePid = Number(props['pipewire.sec.pid']);
+    if (access.includes('flatpak')) {
+      return this._processInTree(securePid, this._rootPid);
+    }
+
+    const processIds = [
+      Number(props['application.process.id']),
+      securePid,
+    ];
+    return processIds.some(pid => this._processInTree(pid, this._rootPid));
+  }
+
+  _restoreRoute(nodeId, route) {
+    if (!route.previousTarget) {
+      const restored = this._runMetadata([
+        '-n', 'default', String(nodeId), 'target.object', String(route.originalSerial), 'Spa:Id',
+      ]);
+      const released = this._runMetadata(['-n', 'default', '-d', String(nodeId), 'target.object']);
+      return restored && released;
+    }
+
+    const { type = 'Spa:Id', value } = route.previousTarget;
+    return this._runMetadata([
+      '-n', 'default', String(nodeId), 'target.object', metadataValue(value, type), type,
+    ]);
+  }
+
+  _runMetadata(args) {
+    try {
+      const result = this._runCommand('pw-metadata', args, {
+        encoding: 'utf8',
+        timeout: 500,
+        windowsHide: true,
+      });
+      if (!result?.error && (result?.status === 0 || result?.status === undefined)) return true;
+      if (!this._warnedMetadata) {
+        const detail = result?.error?.message || String(result?.stderr || '').trim() || 'command failed';
+        this._logger.warn(`[ScreenShare] Could not route native PipeWire audio: ${detail}`);
+        this._warnedMetadata = true;
+      }
+    } catch (err) {
+      if (!this._warnedMetadata) {
+        this._logger.warn(`[ScreenShare] Could not route native PipeWire audio: ${err.message}`);
+        this._warnedMetadata = true;
+      }
+    }
+    return false;
+  }
+}
+
+module.exports = {
+  PipeWireStreamRouter,
+  createJsonArrayParser,
+  isProcessInTree,
+};

--- a/src/main/screen-share-audio.js
+++ b/src/main/screen-share-audio.js
@@ -11,6 +11,63 @@ function resolveAudioSelection(value, audioApps, capabilities) {
   return { type: 'none', app: null };
 }
 
+function shouldDropAudioPacket(capturedAt, now = Date.now(), maxAgeMs = 150) {
+  return !Number.isFinite(capturedAt) || now - capturedAt > maxAgeMs;
+}
+
+class BoundedPcmRing {
+  constructor(capacity) {
+    this._data = new Float32Array(capacity);
+    this._read = 0;
+    this._write = 0;
+    this._available = 0;
+  }
+
+  get available() {
+    return this._available;
+  }
+
+  push(samples) {
+    if (!samples?.length) return 0;
+    const capacity = this._data.length;
+    let dropped = Math.max(0, this._available + samples.length - capacity);
+
+    if (samples.length >= capacity) {
+      this._data.set(samples.subarray(samples.length - capacity));
+      this._read = 0;
+      this._write = 0;
+      this._available = capacity;
+      return dropped;
+    }
+
+    if (dropped) {
+      this._read = (this._read + dropped) % capacity;
+      this._available -= dropped;
+    }
+    for (let i = 0; i < samples.length; i++) {
+      this._data[this._write] = samples[i];
+      this._write = (this._write + 1) % capacity;
+    }
+    this._available += samples.length;
+    return dropped;
+  }
+
+  pull(output) {
+    if (this._available < output.length) {
+      output.fill(0);
+      this._read = this._write;
+      this._available = 0;
+      return false;
+    }
+    for (let i = 0; i < output.length; i++) {
+      output[i] = this._data[this._read];
+      this._read = (this._read + 1) % this._data.length;
+    }
+    this._available -= output.length;
+    return true;
+  }
+}
+
 function createAudioCaptureController(stopCapture) {
   let active = null;
 
@@ -56,4 +113,9 @@ function createAudioCaptureController(stopCapture) {
   };
 }
 
-module.exports = { createAudioCaptureController, resolveAudioSelection };
+module.exports = {
+  BoundedPcmRing,
+  createAudioCaptureController,
+  resolveAudioSelection,
+  shouldDropAudioPacket,
+};

--- a/src/main/screen-share-audio.js
+++ b/src/main/screen-share-audio.js
@@ -1,0 +1,59 @@
+function resolveAudioSelection(value, audioApps, capabilities) {
+  if (value === 'system' && capabilities?.system === true) {
+    return { type: 'system', app: null };
+  }
+
+  if (Number.isSafeInteger(value) && value > 0) {
+    const app = audioApps.find(candidate => candidate.pid === value);
+    if (app) return { type: 'application', app };
+  }
+
+  return { type: 'none', app: null };
+}
+
+function createAudioCaptureController(stopCapture) {
+  let active = null;
+
+  const detach = () => {
+    if (!active) return null;
+    const current = active;
+    active = null;
+    current.owner.removeListener('destroyed', current.cleanup);
+    current.owner.removeListener('render-process-gone', current.cleanup);
+    return current;
+  };
+
+  const stop = (captureId = null, ownerId = null) => {
+    if (!active) return false;
+    if (captureId && active.id !== captureId) return false;
+    if (ownerId && active.ownerId !== ownerId) return false;
+    detach();
+    stopCapture();
+    return true;
+  };
+
+  return {
+    start(captureId, owner) {
+      stop();
+      const ownerId = owner.id;
+      const cleanup = () => stop(captureId, ownerId);
+      active = { id: captureId, ownerId, owner, cleanup };
+      owner.once('destroyed', cleanup);
+      owner.once('render-process-gone', cleanup);
+    },
+    stop,
+    clear(captureId) {
+      if (!active || active.id !== captureId) return false;
+      detach();
+      return true;
+    },
+    isActive(captureId) {
+      return active?.id === captureId;
+    },
+    hasActive() {
+      return active !== null;
+    },
+  };
+}
+
+module.exports = { createAudioCaptureController, resolveAudioSelection };

--- a/test/pipewire-stream-router.test.js
+++ b/test/pipewire-stream-router.test.js
@@ -1,0 +1,248 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const {
+  PipeWireStreamRouter,
+  createJsonArrayParser,
+} = require('../src/main/pipewire-stream-router');
+
+function createMonitor() {
+  const monitor = new EventEmitter();
+  monitor.stdout = new EventEmitter();
+  monitor.kill = () => { monitor.killed = true; };
+  return monitor;
+}
+
+function graph({ previousTarget = null } = {}) {
+  const objects = [
+    {
+      id: 10,
+      type: 'PipeWire:Interface:Node',
+      info: { props: {
+        'media.class': 'Audio/Sink',
+        'node.name': 'HavenCombined_100',
+        'object.serial': 1000,
+      } },
+    },
+    {
+      id: 20,
+      type: 'PipeWire:Interface:Node',
+      info: { props: {
+        'media.class': 'Audio/Sink',
+        'node.name': 'speakers',
+        'object.serial': 2000,
+      } },
+    },
+    {
+      id: 30,
+      type: 'PipeWire:Interface:Client',
+      info: { props: {
+        'application.name': 'Stremio',
+        'application.process.id': 2,
+        'pipewire.access': 'flatpak',
+      } },
+    },
+    {
+      id: 40,
+      type: 'PipeWire:Interface:Node',
+      info: { props: {
+        'client.id': 30,
+        'media.class': 'Stream/Output/Audio',
+        'node.name': 'Stremio audio',
+      } },
+    },
+    {
+      id: 50,
+      type: 'PipeWire:Interface:Link',
+      info: { 'output-node-id': 40, 'input-node-id': 20 },
+    },
+    {
+      id: 31,
+      type: 'PipeWire:Interface:Client',
+      info: { props: {
+        'application.name': 'Chrome',
+        'application.process.id': 300,
+        'client.api': 'pipewire-pulse',
+      } },
+    },
+    {
+      id: 41,
+      type: 'PipeWire:Interface:Node',
+      info: { props: {
+        'client.id': 31,
+        'media.class': 'Stream/Output/Audio',
+        'node.name': 'Chrome audio',
+      } },
+    },
+    {
+      id: 51,
+      type: 'PipeWire:Interface:Link',
+      info: { 'output-node-id': 41, 'input-node-id': 20 },
+    },
+  ];
+
+  if (previousTarget !== null) {
+    objects.push({
+      id: 60,
+      type: 'PipeWire:Interface:Metadata',
+      props: { 'metadata.name': 'default' },
+      metadata: [{
+        subject: 40,
+        key: 'target.object',
+        type: 'Spa:Id',
+        value: previousTarget,
+      }],
+    });
+  }
+  return objects;
+}
+
+test('parses fragmented consecutive pw-dump arrays', () => {
+  const values = [];
+  const parse = createJsonArrayParser(value => values.push(value));
+  parse(' [ {"value":"[x]"');
+  parse('} ]\n[{"value":2}]');
+  assert.deepEqual(values, [[{ value: '[x]' }], [{ value: 2 }]]);
+});
+
+test('routes native Flatpak audio but leaves pipewire-pulse streams alone', () => {
+  const monitor = createMonitor();
+  const commands = [];
+  const router = new PipeWireStreamRouter({
+    spawnProcess: () => monitor,
+    runCommand: (command, args) => {
+      commands.push([command, args]);
+      return { status: 0 };
+    },
+    processInTree: () => false,
+    logger: { warn() {} },
+  });
+
+  assert.equal(router.start('HavenCombined_100', 100), true);
+  monitor.stdout.emit('data', JSON.stringify(graph()));
+  assert.deepEqual(commands, [[
+    'pw-metadata',
+    ['-n', 'default', '40', 'target.object', '1000', 'Spa:Id'],
+  ]]);
+
+  router.stop();
+  assert.equal(monitor.killed, true);
+  assert.deepEqual(commands[1], [
+    'pw-metadata',
+    ['-n', 'default', '40', 'target.object', '2000', 'Spa:Id'],
+  ]);
+  assert.deepEqual(commands[2], [
+    'pw-metadata',
+    ['-n', 'default', '-d', '40', 'target.object'],
+  ]);
+});
+
+test('restores a native stream previous PipeWire target', () => {
+  const monitor = createMonitor();
+  const commands = [];
+  const router = new PipeWireStreamRouter({
+    spawnProcess: () => monitor,
+    runCommand: (_command, args) => {
+      commands.push(args);
+      return { status: 0 };
+    },
+    processInTree: () => false,
+    logger: { warn() {} },
+  });
+
+  router.start('HavenCombined_100', 100);
+  monitor.stdout.emit('data', JSON.stringify(graph({ previousTarget: 2000 })));
+  router.stop();
+
+  assert.deepEqual(commands, [
+    ['-n', 'default', '40', 'target.object', '1000', 'Spa:Id'],
+    ['-n', 'default', '40', 'target.object', '2000', 'Spa:Id'],
+  ]);
+});
+
+test('does not route native streams owned by the Haven process tree', () => {
+  const monitor = createMonitor();
+  const commands = [];
+  const objects = graph();
+  objects[2].info.props['pipewire.access'] = 'unrestricted';
+  objects[2].info.props['application.process.id'] = 101;
+  const router = new PipeWireStreamRouter({
+    spawnProcess: () => monitor,
+    runCommand: (_command, args) => {
+      commands.push(args);
+      return { status: 0 };
+    },
+    processInTree: pid => pid === 101,
+    logger: { warn() {} },
+  });
+
+  router.start('HavenCombined_100', 100);
+  monitor.stdout.emit('data', JSON.stringify(objects));
+  router.stop();
+  assert.deepEqual(commands, []);
+});
+
+test('uses the host security PID to identify an owned Flatpak stream', () => {
+  const monitor = createMonitor();
+  const commands = [];
+  const objects = graph();
+  objects[2].info.props['application.process.id'] = 2;
+  objects[2].info.props['pipewire.sec.pid'] = 500;
+  const router = new PipeWireStreamRouter({
+    spawnProcess: () => monitor,
+    runCommand: (_command, args) => {
+      commands.push(args);
+      return { status: 0 };
+    },
+    processInTree: pid => pid === 500,
+    logger: { warn() {} },
+  });
+
+  router.start('HavenCombined_100', 100);
+  monitor.stdout.emit('data', JSON.stringify(objects));
+  router.stop();
+  assert.deepEqual(commands, []);
+});
+
+test('ignores a Flatpak namespace PID collision when the host PID is external', () => {
+  const monitor = createMonitor();
+  const commands = [];
+  const objects = graph();
+  objects[2].info.props['application.process.id'] = 100;
+  objects[2].info.props['pipewire.sec.pid'] = 500;
+  const router = new PipeWireStreamRouter({
+    spawnProcess: () => monitor,
+    runCommand: (_command, args) => {
+      commands.push(args);
+      return { status: 0 };
+    },
+    processInTree: pid => pid === 100,
+    logger: { warn() {} },
+  });
+
+  router.start('HavenCombined_100', 100);
+  monitor.stdout.emit('data', JSON.stringify(objects));
+  router.stop();
+
+  assert.equal(commands[0][2], '40');
+  assert.equal(commands[0][4], '1000');
+});
+
+test('retries and reports a failed route restoration', () => {
+  const monitor = createMonitor();
+  const warnings = [];
+  let calls = 0;
+  const router = new PipeWireStreamRouter({
+    spawnProcess: () => monitor,
+    runCommand: () => ({ status: calls++ === 0 ? 0 : 1 }),
+    processInTree: () => false,
+    logger: { warn(message) { warnings.push(message); } },
+  });
+
+  router.start('HavenCombined_100', 100);
+  monitor.stdout.emit('data', JSON.stringify(graph()));
+  router.stop();
+
+  assert.equal(calls, 5);
+  assert.equal(warnings.some(message => message.endsWith(': 40')), true);
+});

--- a/test/screen-share-audio.test.js
+++ b/test/screen-share-audio.test.js
@@ -116,3 +116,17 @@ test('ignores native callbacks retained from an older capture generation', () =>
   assert.deepEqual(received, ['new-data:2000', 'new-status']);
   manager.stopCapture();
 });
+
+test('runs capture teardown before stopping the native addon', () => {
+  const events = [];
+  const addon = {
+    startCapture() { return true; },
+    stopCapture() { events.push('native'); },
+  };
+  const manager = new AudioCaptureManager(addon, () => events.push('router'));
+
+  manager.startCapture(1, { onData() {} });
+  manager.stopCapture();
+
+  assert.deepEqual(events, ['router', 'native']);
+});

--- a/test/screen-share-audio.test.js
+++ b/test/screen-share-audio.test.js
@@ -1,9 +1,12 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const { EventEmitter } = require('node:events');
+const { AudioCaptureManager } = require('../src/main/audio-capture');
 const {
+  BoundedPcmRing,
   createAudioCaptureController,
   resolveAudioSelection,
+  shouldDropAudioPacket,
 } = require('../src/main/screen-share-audio');
 
 const apps = [{ pid: 42, name: 'Music' }];
@@ -23,6 +26,36 @@ test('allows system audio only when the platform reports support', () => {
 test('allows only an application listed by the picker', () => {
   assert.equal(resolveAudioSelection(42, apps, {}).app, apps[0]);
   assert.equal(resolveAudioSelection(99, apps, {}).type, 'none');
+});
+
+test('drops stale audio packets before they can add delay', () => {
+  assert.equal(shouldDropAudioPacket(1000, 1149), false);
+  assert.equal(shouldDropAudioPacket(1000, 1151), true);
+  assert.equal(shouldDropAudioPacket(undefined, 1000), true);
+});
+
+test('bounded PCM ring keeps the newest audio when the producer falls behind', () => {
+  const ring = new BoundedPcmRing(4);
+  ring.push(Float32Array.from([1, 2, 3]));
+  assert.equal(ring.push(Float32Array.from([4, 5, 6])), 2);
+  assert.equal(ring.available, 4);
+
+  const output = new Float32Array(4);
+  assert.equal(ring.pull(output), true);
+  assert.deepEqual(Array.from(output), [3, 4, 5, 6]);
+});
+
+test('bounded PCM ring emits silence instead of replaying partial stale audio', () => {
+  const ring = new BoundedPcmRing(4);
+  ring.push(Float32Array.from([1, 2]));
+  const output = Float32Array.from([9, 9, 9]);
+  assert.equal(ring.pull(output), false);
+  assert.deepEqual(Array.from(output), [0, 0, 0]);
+  assert.equal(ring.available, 0);
+
+  ring.push(Float32Array.from([3, 4, 5]));
+  assert.equal(ring.pull(output), true);
+  assert.deepEqual(Array.from(output), [3, 4, 5]);
 });
 
 test('stops captures only for their owner and capture ID', () => {
@@ -51,4 +84,35 @@ test('stops capture when its renderer is destroyed without affecting a newer cap
   second.emit('render-process-gone');
   assert.equal(controller.hasActive(), false);
   assert.equal(stops, 2);
+});
+
+test('ignores native callbacks retained from an older capture generation', () => {
+  const sessions = [];
+  const addon = {
+    startCapture(_pid, _mode, onData, onStatus) {
+      sessions.push({ onData, onStatus });
+      return true;
+    },
+    stopCapture() {},
+  };
+  const manager = new AudioCaptureManager(addon);
+  const received = [];
+
+  manager.startCapture(1, {
+    onData: () => received.push('old-data'),
+    onStatus: () => received.push('old-status'),
+  });
+  manager.stopCapture();
+  manager.startCapture(2, {
+    onData: (_pcm, capturedAt) => received.push(`new-data:${capturedAt}`),
+    onStatus: () => received.push('new-status'),
+  });
+
+  sessions[0].onData(Float32Array.of(1), 1000);
+  sessions[0].onStatus({ kind: 'failed' });
+  sessions[1].onData(Float32Array.of(2), 2000);
+  sessions[1].onStatus({ kind: 'started' });
+
+  assert.deepEqual(received, ['new-data:2000', 'new-status']);
+  manager.stopCapture();
 });

--- a/test/screen-share-audio.test.js
+++ b/test/screen-share-audio.test.js
@@ -1,0 +1,54 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const {
+  createAudioCaptureController,
+  resolveAudioSelection,
+} = require('../src/main/screen-share-audio');
+
+const apps = [{ pid: 42, name: 'Music' }];
+
+test('defaults unknown audio choices to no audio', () => {
+  assert.deepEqual(resolveAudioSelection(undefined, apps, { system: true }), {
+    type: 'none',
+    app: null,
+  });
+});
+
+test('allows system audio only when the platform reports support', () => {
+  assert.equal(resolveAudioSelection('system', apps, { system: true }).type, 'system');
+  assert.equal(resolveAudioSelection('system', apps, { system: false }).type, 'none');
+});
+
+test('allows only an application listed by the picker', () => {
+  assert.equal(resolveAudioSelection(42, apps, {}).app, apps[0]);
+  assert.equal(resolveAudioSelection(99, apps, {}).type, 'none');
+});
+
+test('stops captures only for their owner and capture ID', () => {
+  let stops = 0;
+  const owner = Object.assign(new EventEmitter(), { id: 7 });
+  const controller = createAudioCaptureController(() => { stops++; });
+  controller.start('share-1', owner);
+
+  assert.equal(controller.stop('share-1', 8), false);
+  assert.equal(controller.stop('share-2', 7), false);
+  assert.equal(controller.stop('share-1', 7), true);
+  assert.equal(stops, 1);
+});
+
+test('stops capture when its renderer is destroyed without affecting a newer capture', () => {
+  let stops = 0;
+  const first = Object.assign(new EventEmitter(), { id: 1 });
+  const second = Object.assign(new EventEmitter(), { id: 2 });
+  const controller = createAudioCaptureController(() => { stops++; });
+
+  controller.start('share-1', first);
+  controller.start('share-2', second);
+  first.emit('destroyed');
+  assert.equal(controller.isActive('share-2'), true);
+
+  second.emit('render-process-gone');
+  assert.equal(controller.hasActive(), false);
+  assert.equal(stops, 2);
+});


### PR DESCRIPTION
## Summary

This PR fixes screen-share audio isolation and latency.

System audio sharing now excludes Haven and its child processes, preventing call audio from being captured and sent back to participants. It also removes the accumulated delay caused by oversized native and renderer-side audio buffers.

## Changes

- Adds explicit screen-share options for no audio, system audio without Haven, and individual application audio.
- Implements system audio exclusion on Linux using isolated PulseAudio/PipeWire routing.
- Uses native process-exclusion capture on Windows.
- Excludes the complete Haven process tree, including Chromium's audio service.
- Removes the unsafe Electron loopback fallback that could include Haven audio.
- Restores application audio routes and unloads temporary PulseAudio modules when capture stops.
- Reduces the native capture buffer to 10 ms.
- Limits the native-to-JavaScript queue to prevent unbounded audio accumulation.
- Limits the renderer PCM ring buffer to 100 ms.
- Drops audio packets older than 150 ms.
- Adds capture timestamps before the N-API queue.
- Ignores callbacks retained from previous capture sessions.
- Uses `AudioContext` with the interactive latency hint.
- Improves PulseAudio module cleanup and stream restoration.

## Validation

- `npm test`: 9/9 tests passed.
- Native Linux addon build passed.
- Debian package build and installation passed.
- Validated on Linux, Wayland, PipeWire, and PulseAudio compatibility APIs.
- Runtime capture buffer confirmed as `480/48000`, equivalent to 10 ms.
- Captured packet age confirmed as 0 ms at the JavaScript boundary.
- Haven's audio-service process remained on the original output.
- External applications were routed to the isolated capture output.
- Temporary capture sinks were removed after stopping.

## Notes

Windows uses the native process-loopback exclusion implementation but was not runtime-tested in the Linux development environment.