### PR TITLE
Add native H.264 screen sharing transport

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,35 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install GStreamer SDK
+        shell: pwsh
+        run: |
+          choco install gstreamer gstreamer-devel --version=1.26.9 -y
+          "GSTREAMER_1_0_ROOT_MSVC_X86_64=C:\gstreamer\1.0\msvc_x86_64" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "C:\gstreamer\1.0\msvc_x86_64\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+
       - name: Install dependencies
-        run: npm install
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
 
       - name: Build native audio addon
         run: npm run build:native
+
+      - name: Stage native media runtime
+        run: npm run stage:native-runtime
+
+      - name: Probe staged native media runtime
+        shell: pwsh
+        run: |
+          $env:PATH = "$PWD\native\runtime\gstreamer\bin;$env:PATH"
+          $env:GST_PLUGIN_PATH_1_0 = "$PWD\native\runtime\gstreamer\plugins"
+          $env:GST_PLUGIN_SYSTEM_PATH_1_0 = $env:GST_PLUGIN_PATH_1_0
+          $env:GST_PLUGIN_SCANNER_1_0 = "$PWD\native\runtime\gstreamer\libexec\gst-plugin-scanner.exe"
+          $probeOutput = .\native\build\Release\haven_screen_share.exe --probe | Out-String
+          if ($LASTEXITCODE -ne 0) { Write-Host "Hardware capability unavailable on build runner; validating bundle metadata only." }
+          node -e "const p=JSON.parse(process.argv[1]); if(p.protocolVersion!==2||p.codec!=='H264'||p.components?.capture!==true||p.components?.transport!==true) process.exit(1)" $probeOutput.Trim()
 
       - name: Build & Publish Windows installer
         run: npx electron-builder --win --publish always
@@ -43,7 +67,7 @@ jobs:
   # ─── Linux Build ────────────────────────────────────────
   build-linux:
     needs: [build-windows]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -52,14 +76,25 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install PulseAudio dev headers
-        run: sudo apt-get update && sudo apt-get install -y libpulse-dev libx11-dev libxtst-dev libxinerama-dev libxt-dev libxrandr-dev libxfixes-dev
+      - name: Install native media development packages
+        run: sudo apt-get update && sudo apt-get install -y libpulse-dev libx11-dev libxtst-dev libxinerama-dev libxt-dev libxrandr-dev libxfixes-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-nice gstreamer1.0-pipewire gstreamer1.0-vaapi
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
 
       - name: Build native audio addon
         run: npm run build:native
+
+      - name: Stage native media runtime
+        run: npm run stage:native-runtime
+
+      - name: Probe staged native media runtime
+        run: |
+          probe_output=$(LD_LIBRARY_PATH="$PWD/native/runtime/gstreamer/lib" GST_PLUGIN_PATH_1_0="$PWD/native/runtime/gstreamer/plugins" GST_PLUGIN_SYSTEM_PATH_1_0="$PWD/native/runtime/gstreamer/plugins" GST_PLUGIN_SCANNER_1_0="$PWD/native/runtime/gstreamer/libexec/gst-plugin-scanner" native/build/Release/haven_screen_share --probe || true)
+          node -e "const p=JSON.parse(process.argv[1]); if(p.protocolVersion!==2||p.codec!=='H264'||p.components?.capture!==true||p.components?.transport!==true) process.exit(1)" "$probe_output"
 
       - name: Build & Publish Linux packages
         run: npx electron-builder --linux --publish always

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 native/build/
+native/runtime/
 *.node
 .env
 .DS_Store

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -16,6 +16,7 @@ files:
   - "src/**/*"
   - "assets/**/*"
   - "native/build/Release/*.node"
+  - "native/build/Release/haven_screen_share*"
   - "node_modules/**/*"
   - "!node_modules/**/build/Release/obj*"
   - "package.json"
@@ -56,3 +57,6 @@ extraResources:
     to: native/
     filter:
       - "*.node"
+      - "haven_screen_share*"
+  - from: native/runtime/gstreamer/
+    to: native/gstreamer/

--- a/native/binding.gyp
+++ b/native/binding.gyp
@@ -40,6 +40,46 @@
           "defines": ["PLATFORM_LINUX"]
         }]
       ]
+    },
+    {
+      "target_name": "haven_screen_share",
+      "type": "executable",
+      "sources": ["src/screen_share.cpp"],
+      "conditions": [
+        ["OS=='linux'", {
+          "cflags": [
+            "<!@(pkg-config --cflags gstreamer-1.0 gstreamer-sdp-1.0 gstreamer-webrtc-1.0 gio-2.0 gio-unix-2.0)"
+          ],
+          "cflags_cc": ["-std=c++17", "-fexceptions"],
+          "libraries": [
+            "<!@(pkg-config --libs gstreamer-1.0 gstreamer-sdp-1.0 gstreamer-webrtc-1.0 gio-2.0 gio-unix-2.0)"
+          ]
+        }],
+        ["OS=='win'", {
+          "include_dirs": [
+            "<(gstreamer_root)/include/gstreamer-1.0",
+            "<(gstreamer_root)/include/glib-2.0",
+            "<(gstreamer_root)/lib/glib-2.0/include"
+          ],
+          "libraries": [
+            "<(gstreamer_root)/lib/gstreamer-1.0.lib",
+            "<(gstreamer_root)/lib/gstsdp-1.0.lib",
+            "<(gstreamer_root)/lib/gstwebrtc-1.0.lib",
+            "<(gstreamer_root)/lib/gobject-2.0.lib",
+            "<(gstreamer_root)/lib/glib-2.0.lib",
+            "-luser32.lib"
+          ],
+          "msvs_settings": {
+            "VCCLCompilerTool": {
+              "ExceptionHandling": 1,
+              "AdditionalOptions": ["/std:c++17"]
+            }
+          }
+        }]
+      ]
     }
-  ]
+  ],
+  "variables": {
+    "gstreamer_root%": "<!(node -p \"process.env.GSTREAMER_1_0_ROOT_MSVC_X86_64 || process.env.GSTREAMER_ROOT_X86_64 || 'C:/gstreamer/1.0/msvc_x86_64'\")"
+  }
 }

--- a/native/src/screen_share.cpp
+++ b/native/src/screen_share.cpp
@@ -1,0 +1,1236 @@
+#include <gst/gst.h>
+#include <gst/sdp/sdp.h>
+
+#define GST_USE_UNSTABLE_API
+#include <gst/webrtc/webrtc.h>
+
+#ifndef G_OS_WIN32
+#include <gio/gio.h>
+#include <gio/gunixfdlist.h>
+#include <unistd.h>
+#else
+#include <windows.h>
+#endif
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr int kProtocolVersion = 2;
+
+struct App;
+
+struct Peer {
+  App* app = nullptr;
+  std::string id;
+  GstElement* queue = nullptr;
+  GstElement* capsFilter = nullptr;
+  GstElement* webrtc = nullptr;
+  GstPad* teePad = nullptr;
+  guint64 generation = 0;
+  std::atomic<bool> active{true};
+};
+
+struct TurnServer {
+  std::string url;
+  std::string username;
+  std::string credential;
+};
+
+struct CaptureConfig {
+  std::string sourceKind;
+  std::string sourceHandle;
+  int x = 0;
+  int y = 0;
+  int sourceWidth = 0;
+  int sourceHeight = 0;
+  int outputHeight = 0;
+  int frameRate = 30;
+  int bitrate = 8000000;
+  std::string icePolicy = "all";
+  std::string stunUrl;
+  std::vector<TurnServer> turnServers;
+};
+
+struct App {
+  GMainLoop* loop = nullptr;
+  GstElement* pipeline = nullptr;
+  GstElement* rtpTee = nullptr;
+  guint busWatch = 0;
+  std::string sessionId;
+  CaptureConfig config;
+  std::unordered_map<std::string, std::unique_ptr<Peer>> peers;
+  std::vector<std::unique_ptr<Peer>> retiredPeers;
+  std::mutex outputMutex;
+  bool stopping = false;
+  bool starting = false;
+  bool cancelStartup = false;
+  bool terminalQueued = false;
+  guint64 nextPeerGeneration = 1;
+#ifndef G_OS_WIN32
+  GDBusConnection* portalBus = nullptr;
+  std::string portalSession;
+  guint portalClosedSubscription = 0;
+  GMainLoop* portalRequestLoop = nullptr;
+  int pipewireFd = -1;
+#endif
+};
+
+bool factory_exists(const char* name) {
+  GstElementFactory* factory = gst_element_factory_find(name);
+  if (!factory) return false;
+  gst_object_unref(factory);
+  return true;
+}
+
+bool factory_has_property(const char* factoryName, const char* propertyName) {
+  GstElement* element = gst_element_factory_make(factoryName, nullptr);
+  if (!element) return false;
+  const bool found = g_object_class_find_property(
+      G_OBJECT_GET_CLASS(element), propertyName) != nullptr;
+  gst_object_unref(element);
+  return found;
+}
+
+std::string base64_encode(const std::string& value) {
+  gchar* encoded = g_base64_encode(
+      reinterpret_cast<const guchar*>(value.data()), value.size());
+  std::string result = encoded ? encoded : "";
+  g_free(encoded);
+  return result;
+}
+
+std::string base64_decode(const std::string& value) {
+  gsize length = 0;
+  guchar* decoded = g_base64_decode(value.c_str(), &length);
+  std::string result;
+  if (decoded) result.assign(reinterpret_cast<const char*>(decoded), length);
+  g_free(decoded);
+  return result;
+}
+
+std::vector<std::string> split(const std::string& value, char delimiter) {
+  std::vector<std::string> fields;
+  std::stringstream stream(value);
+  std::string field;
+  while (std::getline(stream, field, delimiter)) fields.push_back(field);
+  if (!value.empty() && value.back() == delimiter) fields.emplace_back();
+  return fields;
+}
+
+std::vector<std::string> decode_command_fields(const std::string& line) {
+  auto fields = split(line, '\t');
+  for (size_t i = 1; i < fields.size(); ++i) fields[i] = base64_decode(fields[i]);
+  return fields;
+}
+
+void emit_event(App* app, const std::string& event,
+                const std::vector<std::string>& fields) {
+  std::lock_guard<std::mutex> lock(app->outputMutex);
+  std::cout << event;
+  for (const auto& field : fields) std::cout << '\t' << base64_encode(field);
+  std::cout << std::endl;
+}
+
+void emit_error(App* app, const std::string& peerId,
+                const std::string& message, bool fatal) {
+  if (app->sessionId.empty()) return;
+  emit_event(app, "ERROR", {
+      app->sessionId, peerId, message, fatal ? "1" : "0",
+  });
+}
+
+bool valid_session_id(const std::string& value) {
+  if (value.size() < 8 || value.size() > 64) return false;
+  return std::all_of(value.begin(), value.end(), [](unsigned char character) {
+    return std::isalnum(character) || character == '_' || character == '-';
+  });
+}
+
+bool parse_int(const std::string& value, int minimum, int maximum, int* output) {
+  try {
+    size_t consumed = 0;
+    long parsed = std::stol(value, &consumed, 10);
+    if (consumed != value.size() || parsed < minimum || parsed > maximum) return false;
+    *output = static_cast<int>(parsed);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+bool parse_u64(const std::string& value, guint64* output) {
+  try {
+    size_t consumed = 0;
+    unsigned long long parsed = std::stoull(value, &consumed, 0);
+    if (consumed != value.size()) return false;
+    *output = static_cast<guint64>(parsed);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+std::string normalize_ice_url(const std::string& url) {
+  const size_t colon = url.find(':');
+  if (colon == std::string::npos || url.compare(colon, 3, "://") == 0) return url;
+  return url.substr(0, colon) + "://" + url.substr(colon + 1);
+}
+
+std::string build_turn_url(const TurnServer& server) {
+  if (server.url.empty()) return {};
+  std::string normalized = normalize_ice_url(server.url);
+  if (server.username.empty()) return normalized;
+  const size_t schemeEnd = normalized.find("://");
+  if (schemeEnd == std::string::npos) return normalized;
+  gchar* user = g_uri_escape_string(server.username.c_str(), nullptr, FALSE);
+  gchar* password = g_uri_escape_string(server.credential.c_str(), nullptr, FALSE);
+  std::string result = normalized.substr(0, schemeEnd + 3) +
+      (user ? user : "") + ":" + (password ? password : "") + "@" +
+      normalized.substr(schemeEnd + 3);
+  g_free(user);
+  g_free(password);
+  return result;
+}
+
+std::vector<TurnServer> parse_turn_servers(const std::string& encoded) {
+  std::vector<TurnServer> servers;
+  for (const auto& record : split(encoded, ';')) {
+    const auto fields = split(record, ',');
+    if (fields.size() != 3) continue;
+    TurnServer server{
+        base64_decode(fields[0]), base64_decode(fields[1]), base64_decode(fields[2]),
+    };
+    if (!server.url.empty()) servers.push_back(std::move(server));
+    if (servers.size() >= 16) break;
+  }
+  return servers;
+}
+
+std::string output_caps(const CaptureConfig& config, bool d3d11Memory) {
+  std::ostringstream caps;
+  caps << (d3d11Memory ? "video/x-raw(memory:D3D11Memory)" : "video/x-raw")
+       << ",format=NV12,framerate=" << config.frameRate << "/1";
+  if (config.outputHeight > 0) {
+    if (config.sourceWidth > 0 && config.sourceHeight > 0) {
+      int width = static_cast<int>(
+          static_cast<int64_t>(config.sourceWidth) * config.outputHeight /
+          config.sourceHeight);
+      width = std::max(2, width & ~1);
+      caps << ",width=" << width;
+    }
+    caps << ",height=" << (config.outputHeight & ~1);
+  }
+  return caps.str();
+}
+
+#ifndef G_OS_WIN32
+void queue_terminal_stop(App* app);
+
+constexpr const char* kPortalBusName = "org.freedesktop.portal.Desktop";
+constexpr const char* kPortalObjectPath = "/org/freedesktop/portal/desktop";
+
+struct PortalResponse {
+  GMainLoop* loop = nullptr;
+  std::string path;
+  GVariant* results = nullptr;
+  guint response = 2;
+  bool received = false;
+  bool timedOut = false;
+};
+
+std::string portal_token(const char* prefix) {
+  gchar* uuid = g_uuid_string_random();
+  std::string token = std::string(prefix) + (uuid ? uuid : "request");
+  g_free(uuid);
+  std::replace(token.begin(), token.end(), '-', '_');
+  return token;
+}
+
+void on_portal_response(GDBusConnection*, const gchar*, const gchar* objectPath,
+                        const gchar*, const gchar*, GVariant* parameters,
+                        gpointer userData) {
+  auto* pending = static_cast<PortalResponse*>(userData);
+  if (pending->received || pending->path != objectPath) return;
+  g_variant_get(parameters, "(u@a{sv})", &pending->response, &pending->results);
+  pending->received = true;
+  g_main_loop_quit(pending->loop);
+}
+
+gboolean on_portal_timeout(gpointer userData) {
+  auto* pending = static_cast<PortalResponse*>(userData);
+  pending->timedOut = true;
+  g_main_loop_quit(pending->loop);
+  return G_SOURCE_REMOVE;
+}
+
+bool portal_request(App* app, const char* method,
+                     GVariant* parameters, GVariant** results,
+                     std::string* error) {
+  GDBusConnection* bus = app->portalBus;
+  PortalResponse pending;
+  pending.loop = g_main_loop_new(nullptr, FALSE);
+  const guint subscription = g_dbus_connection_signal_subscribe(
+      bus, kPortalBusName, "org.freedesktop.portal.Request", "Response",
+      nullptr, nullptr, G_DBUS_SIGNAL_FLAGS_NONE, on_portal_response,
+      &pending, nullptr);
+
+  GError* callError = nullptr;
+  GVariant* reply = g_dbus_connection_call_sync(
+      bus, kPortalBusName, kPortalObjectPath,
+      "org.freedesktop.portal.ScreenCast", method, parameters,
+      G_VARIANT_TYPE("(o)"), G_DBUS_CALL_FLAGS_NONE, 10000, nullptr,
+      &callError);
+  if (!reply) {
+    *error = callError ? callError->message : "Desktop portal request failed";
+    g_clear_error(&callError);
+    g_dbus_connection_signal_unsubscribe(bus, subscription);
+    g_main_loop_unref(pending.loop);
+    return false;
+  }
+
+  const gchar* requestPath = nullptr;
+  g_variant_get(reply, "(&o)", &requestPath);
+  pending.path = requestPath ? requestPath : "";
+  g_variant_unref(reply);
+
+  const guint timeout = g_timeout_add_seconds(120, on_portal_timeout, &pending);
+  app->portalRequestLoop = pending.loop;
+  g_main_loop_run(pending.loop);
+  app->portalRequestLoop = nullptr;
+  if (!pending.timedOut) g_source_remove(timeout);
+  g_dbus_connection_signal_unsubscribe(bus, subscription);
+  g_main_loop_unref(pending.loop);
+
+  if (pending.timedOut) {
+    *error = "Desktop portal screen selection timed out";
+    return false;
+  }
+  if (!pending.received || pending.response != 0 || !pending.results) {
+    if (pending.results) g_variant_unref(pending.results);
+    *error = pending.response == 1
+        ? "Desktop portal screen selection was cancelled"
+        : "Desktop portal rejected the screen capture request";
+    return false;
+  }
+  *results = pending.results;
+  return true;
+}
+
+void on_portal_session_closed(GDBusConnection*, const gchar*, const gchar*,
+                              const gchar*, const gchar*, GVariant*,
+                              gpointer userData) {
+  App* app = static_cast<App*>(userData);
+  if (app->stopping) return;
+  emit_error(app, "", "Desktop portal screen capture session closed", true);
+  if (app->starting) {
+    app->cancelStartup = true;
+    if (app->portalRequestLoop) g_main_loop_quit(app->portalRequestLoop);
+    return;
+  }
+  queue_terminal_stop(app);
+}
+
+void close_portal_capture(App* app) {
+  if (app->portalBus && app->portalClosedSubscription) {
+    g_dbus_connection_signal_unsubscribe(
+        app->portalBus, app->portalClosedSubscription);
+    app->portalClosedSubscription = 0;
+  }
+  if (app->portalBus && !app->portalSession.empty()) {
+    GError* error = nullptr;
+    GVariant* reply = g_dbus_connection_call_sync(
+        app->portalBus, kPortalBusName, app->portalSession.c_str(),
+        "org.freedesktop.portal.Session", "Close", nullptr,
+        G_VARIANT_TYPE_UNIT, G_DBUS_CALL_FLAGS_NONE, 2000, nullptr, &error);
+    if (reply) g_variant_unref(reply);
+    g_clear_error(&error);
+  }
+  if (app->pipewireFd >= 0) {
+    close(app->pipewireFd);
+    app->pipewireFd = -1;
+  }
+  app->portalSession.clear();
+  g_clear_object(&app->portalBus);
+}
+
+guint portal_cursor_mode(GDBusConnection* bus) {
+  GError* error = nullptr;
+  GVariant* reply = g_dbus_connection_call_sync(
+      bus, kPortalBusName, kPortalObjectPath,
+      "org.freedesktop.DBus.Properties", "Get",
+      g_variant_new("(ss)", "org.freedesktop.portal.ScreenCast",
+                    "AvailableCursorModes"),
+      G_VARIANT_TYPE("(v)"), G_DBUS_CALL_FLAGS_NONE, 5000, nullptr, &error);
+  g_clear_error(&error);
+  if (!reply) return 1;
+  GVariant* value = nullptr;
+  g_variant_get(reply, "(@v)", &value);
+  GVariant* modes = g_variant_get_variant(value);
+  const guint available = g_variant_get_uint32(modes);
+  g_variant_unref(modes);
+  g_variant_unref(value);
+  g_variant_unref(reply);
+  return (available & 2U) ? 2U : 1U;
+}
+
+bool open_pipewire_portal(App* app, CaptureConfig* config,
+                          std::ostringstream* source, std::string* error) {
+  GError* busError = nullptr;
+  app->portalBus = g_bus_get_sync(G_BUS_TYPE_SESSION, nullptr, &busError);
+  if (!app->portalBus) {
+    *error = busError ? busError->message : "Could not connect to the session bus";
+    g_clear_error(&busError);
+    return false;
+  }
+
+  const std::string createToken = portal_token("haven_create_");
+  const std::string sessionToken = portal_token("haven_session_");
+  GVariantBuilder createOptions;
+  g_variant_builder_init(&createOptions, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_add(&createOptions, "{sv}", "handle_token",
+                        g_variant_new_string(createToken.c_str()));
+  g_variant_builder_add(&createOptions, "{sv}", "session_handle_token",
+                        g_variant_new_string(sessionToken.c_str()));
+  GVariant* results = nullptr;
+  if (!portal_request(app, "CreateSession",
+                      g_variant_new("(@a{sv})", g_variant_builder_end(&createOptions)),
+                      &results, error)) {
+    close_portal_capture(app);
+    return false;
+  }
+
+  GVariant* session = g_variant_lookup_value(
+      results, "session_handle", G_VARIANT_TYPE_STRING);
+  if (session) app->portalSession = g_variant_get_string(session, nullptr);
+  if (session) g_variant_unref(session);
+  g_variant_unref(results);
+  if (app->portalSession.empty()) {
+    *error = "Desktop portal returned no screen capture session";
+    close_portal_capture(app);
+    return false;
+  }
+
+  app->portalClosedSubscription = g_dbus_connection_signal_subscribe(
+      app->portalBus, kPortalBusName, "org.freedesktop.portal.Session",
+      "Closed", app->portalSession.c_str(), nullptr,
+      G_DBUS_SIGNAL_FLAGS_NONE, on_portal_session_closed, app, nullptr);
+
+  const std::string selectToken = portal_token("haven_select_");
+  GVariantBuilder selectOptions;
+  g_variant_builder_init(&selectOptions, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_add(&selectOptions, "{sv}", "handle_token",
+                        g_variant_new_string(selectToken.c_str()));
+  g_variant_builder_add(&selectOptions, "{sv}", "types",
+                        g_variant_new_uint32(3));
+  g_variant_builder_add(&selectOptions, "{sv}", "multiple",
+                        g_variant_new_boolean(FALSE));
+  g_variant_builder_add(&selectOptions, "{sv}", "cursor_mode",
+                        g_variant_new_uint32(portal_cursor_mode(app->portalBus)));
+  if (!portal_request(app, "SelectSources",
+                      g_variant_new("(o@a{sv})", app->portalSession.c_str(),
+                                    g_variant_builder_end(&selectOptions)),
+                      &results, error)) {
+    close_portal_capture(app);
+    return false;
+  }
+  g_variant_unref(results);
+
+  const std::string startToken = portal_token("haven_start_");
+  GVariantBuilder startOptions;
+  g_variant_builder_init(&startOptions, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_add(&startOptions, "{sv}", "handle_token",
+                        g_variant_new_string(startToken.c_str()));
+  if (!portal_request(app, "Start",
+                      g_variant_new("(os@a{sv})", app->portalSession.c_str(), "",
+                                    g_variant_builder_end(&startOptions)),
+                      &results, error)) {
+    close_portal_capture(app);
+    return false;
+  }
+
+  GVariant* streams = g_variant_lookup_value(
+      results, "streams", G_VARIANT_TYPE("a(ua{sv})"));
+  if (!streams || g_variant_n_children(streams) == 0) {
+    if (streams) g_variant_unref(streams);
+    g_variant_unref(results);
+    *error = "Desktop portal returned no PipeWire stream";
+    close_portal_capture(app);
+    return false;
+  }
+
+  guint nodeId = 0;
+  GVariant* properties = nullptr;
+  GVariant* firstStream = g_variant_get_child_value(streams, 0);
+  g_variant_get(firstStream, "(u@a{sv})", &nodeId, &properties);
+  guint64 serial = 0;
+  g_variant_lookup(properties, "pipewire-serial", "t", &serial);
+  GVariant* size = g_variant_lookup_value(properties, "size", G_VARIANT_TYPE("(ii)"));
+  if (size) {
+    g_variant_get(size, "(ii)", &config->sourceWidth, &config->sourceHeight);
+    g_variant_unref(size);
+  }
+  g_variant_unref(properties);
+  g_variant_unref(firstStream);
+  g_variant_unref(streams);
+  g_variant_unref(results);
+
+  GUnixFDList* descriptors = nullptr;
+  GError* remoteError = nullptr;
+  GVariantBuilder remoteOptions;
+  g_variant_builder_init(&remoteOptions, G_VARIANT_TYPE_VARDICT);
+  GVariant* remote = g_dbus_connection_call_with_unix_fd_list_sync(
+      app->portalBus, kPortalBusName, kPortalObjectPath,
+      "org.freedesktop.portal.ScreenCast", "OpenPipeWireRemote",
+      g_variant_new("(o@a{sv})", app->portalSession.c_str(),
+                    g_variant_builder_end(&remoteOptions)),
+      G_VARIANT_TYPE("(h)"), G_DBUS_CALL_FLAGS_NONE, 10000, nullptr,
+      &descriptors, nullptr, &remoteError);
+  if (!remote) {
+    *error = remoteError ? remoteError->message : "Could not open the PipeWire remote";
+    g_clear_error(&remoteError);
+    if (descriptors) g_object_unref(descriptors);
+    close_portal_capture(app);
+    return false;
+  }
+
+  gint descriptorIndex = -1;
+  g_variant_get(remote, "(h)", &descriptorIndex);
+  g_variant_unref(remote);
+  app->pipewireFd = g_unix_fd_list_get(descriptors, descriptorIndex, &remoteError);
+  g_object_unref(descriptors);
+  if (app->pipewireFd < 0) {
+    *error = remoteError ? remoteError->message : "Desktop portal returned no PipeWire descriptor";
+    g_clear_error(&remoteError);
+    close_portal_capture(app);
+    return false;
+  }
+
+  *source << "pipewiresrc fd=" << app->pipewireFd;
+  if (serial > 0 && factory_has_property("pipewiresrc", "target-object")) {
+    *source << " target-object=" << serial;
+  } else {
+    *source << " path=" << nodeId;
+  }
+  if (factory_has_property("pipewiresrc", "on-disconnect")) {
+    *source << " on-disconnect=error";
+  }
+  *source << " do-timestamp=true";
+  return true;
+}
+#endif
+
+bool build_pipeline_description(App* app, CaptureConfig config,
+                                 std::string* description,
+                                std::string* encoderName,
+                                std::string* error) {
+  std::ostringstream source;
+  bool d3d11 = false;
+
+#ifdef G_OS_WIN32
+  (void)app;
+  guint64 handle = 0;
+  if (config.sourceKind == "test") {
+    source << "videotestsrc is-live=true pattern=ball";
+  } else if (config.sourceKind == "windows-window") {
+    if (!parse_u64(config.sourceHandle, &handle)) {
+      *error = "Invalid Windows capture handle";
+      return false;
+    }
+    d3d11 = true;
+    source << "d3d11screencapturesrc capture-api=wgc window-handle=" << handle
+           << " show-cursor=true";
+  } else if (config.sourceKind == "windows-monitor") {
+    const POINT point{config.x, config.y};
+    const HMONITOR monitor = MonitorFromPoint(point, MONITOR_DEFAULTTONULL);
+    if (!monitor) {
+      *error = "Selected Windows monitor is no longer available";
+      return false;
+    }
+    d3d11 = true;
+    source << "d3d11screencapturesrc monitor-handle="
+           << reinterpret_cast<uintptr_t>(monitor)
+           << " show-cursor=true";
+  } else {
+    *error = "Unsupported Windows capture source";
+    return false;
+  }
+  *encoderName = "mfh264enc";
+#else
+  guint64 handle = 0;
+  if (config.sourceKind == "linux-pipewire") {
+    if (!open_pipewire_portal(app, &config, &source, error)) return false;
+  } else if (config.sourceKind == "linux-x11-window") {
+    if (!parse_u64(config.sourceHandle, &handle)) {
+      *error = "Invalid X11 window identifier";
+      return false;
+    }
+    source << "ximagesrc xid=" << handle << " show-pointer=true use-damage=false";
+  } else if (config.sourceKind == "linux-x11-screen") {
+    source << "ximagesrc xid=0 show-pointer=true use-damage=false";
+    if (config.sourceWidth > 0 && config.sourceHeight > 0) {
+      source << " startx=" << std::max(0, config.x)
+             << " starty=" << std::max(0, config.y)
+             << " endx=" << std::max(0, config.x) + config.sourceWidth - 1
+             << " endy=" << std::max(0, config.y) + config.sourceHeight - 1;
+    }
+  } else if (config.sourceKind == "test") {
+    source << "videotestsrc is-live=true pattern=ball";
+  } else {
+    *error = "Unsupported Linux capture source";
+    return false;
+  }
+  if (factory_exists("vah264enc")) {
+    *encoderName = "vah264enc";
+  } else if (factory_exists("vaapih264enc")) {
+    *encoderName = "vaapih264enc";
+  } else {
+    *error = "No VA-API H.264 encoder is available";
+    return false;
+  }
+#endif
+
+  const int bitrateKbps = std::max(250, config.bitrate / 1000);
+  const int keyInterval = std::max(1, config.frameRate * 2);
+  std::ostringstream pipeline;
+  pipeline << source.str()
+           << " ! queue max-size-buffers=2 leaky=downstream"
+           << " ! videorate drop-only=true";
+
+  if (d3d11) {
+    pipeline << " ! d3d11convert ! " << output_caps(config, true)
+             << " ! mfh264enc bitrate=" << bitrateKbps
+             << " max-bitrate=" << bitrateKbps
+             << " rc-mode=cbr low-latency=true bframes=0 gop-size=" << keyInterval;
+  } else if (*encoderName == "mfh264enc") {
+    pipeline << " ! videoscale add-borders=false ! videoconvert ! "
+             << output_caps(config, false)
+             << " ! mfh264enc bitrate=" << bitrateKbps
+             << " max-bitrate=" << bitrateKbps
+             << " rc-mode=cbr low-latency=true bframes=0 gop-size=" << keyInterval;
+  } else {
+    pipeline << " ! videoscale add-borders=false ! videoconvert ! "
+             << output_caps(config, false) << " ! " << *encoderName
+             << " bitrate=" << bitrateKbps << " rate-control=cbr";
+    if (*encoderName == "vah264enc") {
+      pipeline << " target-usage=7 b-frames=0 key-int-max=" << keyInterval;
+    } else {
+      pipeline << " quality-level=7 max-bframes=0 keyframe-period=" << keyInterval;
+    }
+  }
+
+  pipeline << " ! video/x-h264,profile=constrained-baseline"
+           << " ! h264parse config-interval=-1"
+           << " ! rtph264pay pt=96 config-interval=-1 aggregate-mode=zero-latency"
+           << " ! application/x-rtp,media=video,encoding-name=H264,payload=96,clock-rate=90000"
+           << " ! tee name=rtptee rtptee. ! queue ! fakesink sync=false";
+  *description = pipeline.str();
+  return true;
+}
+
+void stop_pipeline(App* app);
+
+gboolean stop_after_terminal_message(gpointer userData) {
+  App* app = static_cast<App*>(userData);
+  if (!app->stopping) {
+    app->stopping = true;
+    stop_pipeline(app);
+    g_main_loop_quit(app->loop);
+  }
+  return G_SOURCE_REMOVE;
+}
+
+void queue_terminal_stop(App* app) {
+  if (app->terminalQueued || app->stopping) return;
+  app->terminalQueued = true;
+  g_idle_add(stop_after_terminal_message, app);
+}
+
+gboolean bus_watch_cb(GstBus*, GstMessage* message, gpointer userData) {
+  App* app = static_cast<App*>(userData);
+  if (GST_MESSAGE_TYPE(message) == GST_MESSAGE_ERROR) {
+    GError* error = nullptr;
+    gchar* debug = nullptr;
+    gst_message_parse_error(message, &error, &debug);
+    const std::string text = error ? error->message : "Unknown GStreamer error";
+    std::cerr << "[NativeScreen] " << text;
+    if (debug) std::cerr << " (" << debug << ")";
+    std::cerr << std::endl;
+    emit_error(app, "", text, true);
+    queue_terminal_stop(app);
+    g_clear_error(&error);
+    g_free(debug);
+  } else if (GST_MESSAGE_TYPE(message) == GST_MESSAGE_EOS) {
+    emit_error(app, "", "Screen capture ended", true);
+    queue_terminal_stop(app);
+  } else if (GST_MESSAGE_TYPE(message) == GST_MESSAGE_WARNING) {
+    GError* warning = nullptr;
+    gchar* debug = nullptr;
+    gst_message_parse_warning(message, &warning, &debug);
+    std::cerr << "[NativeScreen] warning: "
+              << (warning ? warning->message : "unknown") << std::endl;
+    g_clear_error(&warning);
+    g_free(debug);
+  }
+  return G_SOURCE_CONTINUE;
+}
+
+struct PendingOffer {
+  App* app;
+  std::string peerId;
+  guint64 generation;
+  GstWebRTCSessionDescription* offer;
+};
+
+gboolean dispatch_offer(gpointer userData) {
+  std::unique_ptr<PendingOffer> pending(static_cast<PendingOffer*>(userData));
+  auto found = pending->app->peers.find(pending->peerId);
+  if (found != pending->app->peers.end() &&
+      found->second->generation == pending->generation &&
+      found->second->active.load() &&
+      found->second->webrtc) {
+    Peer* peer = found->second.get();
+    GstPromise* localPromise = gst_promise_new();
+    g_signal_emit_by_name(peer->webrtc, "set-local-description",
+                          pending->offer, localPromise);
+    gst_promise_interrupt(localPromise);
+    gst_promise_unref(localPromise);
+
+    gchar* sdp = gst_sdp_message_as_text(pending->offer->sdp);
+    if (sdp) emit_event(pending->app, "OFFER", {
+        pending->app->sessionId, pending->peerId, sdp,
+    });
+    g_free(sdp);
+  }
+  gst_webrtc_session_description_free(pending->offer);
+  return G_SOURCE_REMOVE;
+}
+
+struct OfferRequest {
+  App* app;
+  std::string peerId;
+  guint64 generation;
+};
+
+void on_offer_created(GstPromise* promise, gpointer userData) {
+  std::unique_ptr<OfferRequest> request(static_cast<OfferRequest*>(userData));
+
+  const GstStructure* reply = gst_promise_get_reply(promise);
+  GstWebRTCSessionDescription* offer = nullptr;
+  if (!reply || !gst_structure_get(reply, "offer",
+                                    GST_TYPE_WEBRTC_SESSION_DESCRIPTION,
+                                    &offer, nullptr) || !offer) {
+    gst_promise_unref(promise);
+    emit_error(request->app, request->peerId,
+               "Failed to create WebRTC offer", false);
+    return;
+  }
+  gst_promise_unref(promise);
+  auto* pending = new PendingOffer{
+      request->app, request->peerId, request->generation, offer,
+  };
+  g_main_context_invoke(nullptr, dispatch_offer, pending);
+}
+
+void on_negotiation_needed(GstElement* webrtc, gpointer userData) {
+  Peer* peer = static_cast<Peer*>(userData);
+  if (!peer->active.load()) return;
+  auto* request = new OfferRequest{peer->app, peer->id, peer->generation};
+  GstPromise* promise = gst_promise_new_with_change_func(
+      on_offer_created, request, nullptr);
+  g_signal_emit_by_name(webrtc, "create-offer", nullptr, promise);
+}
+
+struct PendingIce {
+  App* app;
+  std::string peerId;
+  guint64 generation;
+  guint mlineIndex;
+  std::string candidate;
+  bool end;
+};
+
+gboolean dispatch_ice(gpointer userData) {
+  std::unique_ptr<PendingIce> pending(static_cast<PendingIce*>(userData));
+  auto found = pending->app->peers.find(pending->peerId);
+  if (found == pending->app->peers.end() ||
+      found->second->generation != pending->generation ||
+      !found->second->active.load()) {
+    return G_SOURCE_REMOVE;
+  }
+  emit_event(pending->app, "ICE", {
+      pending->app->sessionId,
+      pending->peerId,
+      pending->candidate,
+      "",
+      std::to_string(pending->mlineIndex),
+      "",
+      pending->end ? "1" : "0",
+  });
+  return G_SOURCE_REMOVE;
+}
+
+void on_ice_candidate(GstElement*, guint mlineIndex, gchar* candidate,
+                       gpointer userData) {
+  Peer* peer = static_cast<Peer*>(userData);
+  if (!peer->active.load()) return;
+  auto* pending = new PendingIce{
+      peer->app, peer->id, peer->generation, mlineIndex,
+      candidate ? candidate : "", !candidate,
+  };
+  g_main_context_invoke(nullptr, dispatch_ice, pending);
+}
+
+void configure_ice(Peer* peer) {
+  const CaptureConfig& config = peer->app->config;
+  const std::string stun = normalize_ice_url(config.stunUrl);
+  if (!stun.empty()) g_object_set(peer->webrtc, "stun-server", stun.c_str(), nullptr);
+  const guint addTurnSignal = g_signal_lookup(
+      "add-turn-server", G_OBJECT_TYPE(peer->webrtc));
+  bool configuredTurn = false;
+  for (const auto& server : config.turnServers) {
+    const std::string turn = build_turn_url(server);
+    if (turn.empty()) continue;
+    if (addTurnSignal) {
+      gboolean added = FALSE;
+      g_signal_emit_by_name(peer->webrtc, "add-turn-server", turn.c_str(), &added);
+      configuredTurn = configuredTurn || added;
+    } else if (!configuredTurn) {
+      g_object_set(peer->webrtc, "turn-server", turn.c_str(), nullptr);
+      configuredTurn = true;
+    }
+  }
+  g_object_set(peer->webrtc,
+               "bundle-policy", GST_WEBRTC_BUNDLE_POLICY_MAX_BUNDLE,
+               "ice-transport-policy",
+               config.icePolicy == "relay" ? GST_WEBRTC_ICE_TRANSPORT_POLICY_RELAY
+                                            : GST_WEBRTC_ICE_TRANSPORT_POLICY_ALL,
+               nullptr);
+}
+
+bool add_peer(App* app, const std::string& peerId, std::string* error) {
+  if (peerId.empty() || app->peers.count(peerId)) return true;
+  auto peer = std::make_unique<Peer>();
+  peer->app = app;
+  peer->id = peerId;
+  peer->generation = app->nextPeerGeneration++;
+  peer->queue = gst_element_factory_make("queue", nullptr);
+  peer->capsFilter = gst_element_factory_make("capsfilter", nullptr);
+  peer->webrtc = gst_element_factory_make("webrtcbin", nullptr);
+  if (!peer->queue || !peer->capsFilter || !peer->webrtc) {
+    *error = "Could not create per-viewer WebRTC elements";
+    if (peer->queue) gst_object_unref(peer->queue);
+    if (peer->capsFilter) gst_object_unref(peer->capsFilter);
+    if (peer->webrtc) gst_object_unref(peer->webrtc);
+    return false;
+  }
+
+  g_object_set(peer->queue,
+               "max-size-buffers", 4,
+               "max-size-bytes", 0,
+               "max-size-time", static_cast<guint64>(0),
+               "leaky", 2,
+               nullptr);
+  GstCaps* rtpCaps = gst_caps_from_string(
+      "application/x-rtp,media=video,encoding-name=H264,payload=96,clock-rate=90000");
+  g_object_set(peer->capsFilter, "caps", rtpCaps, nullptr);
+  gst_caps_unref(rtpCaps);
+  configure_ice(peer.get());
+  g_signal_connect(peer->webrtc, "on-negotiation-needed",
+                   G_CALLBACK(on_negotiation_needed), peer.get());
+  g_signal_connect(peer->webrtc, "on-ice-candidate",
+                   G_CALLBACK(on_ice_candidate), peer.get());
+
+  gst_bin_add_many(GST_BIN(app->pipeline), peer->queue, peer->capsFilter,
+                   peer->webrtc, nullptr);
+  if (!gst_element_link_many(peer->queue, peer->capsFilter, peer->webrtc, nullptr)) {
+    *error = "Could not link viewer queue to webrtcbin";
+    peer->active = false;
+    gst_bin_remove_many(GST_BIN(app->pipeline), peer->queue, peer->capsFilter,
+                        peer->webrtc, nullptr);
+    peer->queue = nullptr;
+    peer->capsFilter = nullptr;
+    peer->webrtc = nullptr;
+    return false;
+  }
+
+  peer->teePad = gst_element_request_pad_simple(app->rtpTee, "src_%u");
+  GstPad* queueSink = gst_element_get_static_pad(peer->queue, "sink");
+  const GstPadLinkReturn linkResult = peer->teePad && queueSink
+      ? gst_pad_link(peer->teePad, queueSink)
+      : GST_PAD_LINK_REFUSED;
+  if (queueSink) gst_object_unref(queueSink);
+  if (linkResult != GST_PAD_LINK_OK) {
+    *error = "Could not attach viewer to encoded RTP stream";
+    peer->active = false;
+    if (peer->teePad) {
+      gst_element_release_request_pad(app->rtpTee, peer->teePad);
+      gst_object_unref(peer->teePad);
+      peer->teePad = nullptr;
+    }
+    gst_element_set_state(peer->queue, GST_STATE_NULL);
+    gst_element_set_state(peer->capsFilter, GST_STATE_NULL);
+    gst_element_set_state(peer->webrtc, GST_STATE_NULL);
+    gst_bin_remove_many(GST_BIN(app->pipeline), peer->queue, peer->capsFilter,
+                        peer->webrtc, nullptr);
+    peer->queue = nullptr;
+    peer->capsFilter = nullptr;
+    peer->webrtc = nullptr;
+    return false;
+  }
+
+  gst_element_sync_state_with_parent(peer->queue);
+  gst_element_sync_state_with_parent(peer->capsFilter);
+  gst_element_sync_state_with_parent(peer->webrtc);
+
+  GArray* transceivers = nullptr;
+  g_signal_emit_by_name(peer->webrtc, "get-transceivers", &transceivers);
+  if (transceivers && transceivers->len > 0) {
+    auto* transceiver = g_array_index(
+        transceivers, GstWebRTCRTPTransceiver*, 0);
+    g_object_set(transceiver, "direction",
+                 GST_WEBRTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY, nullptr);
+    g_array_unref(transceivers);
+  }
+
+  app->peers.emplace(peerId, std::move(peer));
+  return true;
+}
+
+void remove_peer(App* app, const std::string& peerId) {
+  auto found = app->peers.find(peerId);
+  if (found == app->peers.end()) return;
+  std::unique_ptr<Peer> peer = std::move(found->second);
+  app->peers.erase(found);
+  peer->active = false;
+
+  if (peer->webrtc) g_signal_handlers_disconnect_by_data(peer->webrtc, peer.get());
+  if (peer->teePad && peer->queue) {
+    gst_pad_set_active(peer->teePad, FALSE);
+    GstPad* queueSink = gst_element_get_static_pad(peer->queue, "sink");
+    if (queueSink) {
+      gst_pad_unlink(peer->teePad, queueSink);
+      gst_object_unref(queueSink);
+    }
+  }
+  if (peer->teePad) {
+    gst_element_release_request_pad(app->rtpTee, peer->teePad);
+    gst_object_unref(peer->teePad);
+    peer->teePad = nullptr;
+  }
+  if (peer->queue) gst_element_set_state(peer->queue, GST_STATE_NULL);
+  if (peer->capsFilter) gst_element_set_state(peer->capsFilter, GST_STATE_NULL);
+  if (peer->webrtc) gst_element_set_state(peer->webrtc, GST_STATE_NULL);
+  if (peer->queue && peer->capsFilter && peer->webrtc) {
+    gst_bin_remove_many(GST_BIN(app->pipeline), peer->queue, peer->capsFilter,
+                        peer->webrtc, nullptr);
+  }
+  peer->queue = nullptr;
+  peer->capsFilter = nullptr;
+  peer->webrtc = nullptr;
+  app->retiredPeers.push_back(std::move(peer));
+}
+
+void stop_pipeline(App* app) {
+  for (auto& entry : app->peers) {
+    Peer* peer = entry.second.get();
+    peer->active = false;
+    if (peer->webrtc) g_signal_handlers_disconnect_by_data(peer->webrtc, peer);
+  }
+
+  if (app->busWatch) {
+    g_source_remove(app->busWatch);
+    app->busWatch = 0;
+  }
+  if (app->pipeline) {
+    gst_element_set_state(app->pipeline, GST_STATE_NULL);
+    for (auto& entry : app->peers) {
+      Peer* peer = entry.second.get();
+      if (peer->teePad) {
+        gst_element_release_request_pad(app->rtpTee, peer->teePad);
+        gst_object_unref(peer->teePad);
+        peer->teePad = nullptr;
+      }
+      peer->queue = nullptr;
+      peer->capsFilter = nullptr;
+      peer->webrtc = nullptr;
+    }
+    gst_object_unref(app->pipeline);
+    app->pipeline = nullptr;
+    app->rtpTee = nullptr;
+  }
+  for (auto& entry : app->peers) {
+    app->retiredPeers.push_back(std::move(entry.second));
+  }
+  app->peers.clear();
+#ifndef G_OS_WIN32
+  close_portal_capture(app);
+#endif
+}
+
+bool start_pipeline(App* app, const CaptureConfig& config, std::string* error) {
+  std::string pipelineDescription;
+  std::string encoder;
+  if (!build_pipeline_description(app, config, &pipelineDescription, &encoder, error)) {
+    return false;
+  }
+  if (!factory_exists("webrtcbin") || !factory_exists("rtph264pay") ||
+      !factory_exists("h264parse") || !factory_exists(encoder.c_str())) {
+    *error = "Required GStreamer WebRTC/H.264 plugins are unavailable";
+    return false;
+  }
+
+  GError* parseError = nullptr;
+  app->pipeline = gst_parse_launch(pipelineDescription.c_str(), &parseError);
+  if (!app->pipeline || parseError) {
+    *error = parseError ? parseError->message : "Could not create capture pipeline";
+    g_clear_error(&parseError);
+    if (app->pipeline) {
+      gst_object_unref(app->pipeline);
+      app->pipeline = nullptr;
+    }
+    return false;
+  }
+  app->rtpTee = gst_bin_get_by_name(GST_BIN(app->pipeline), "rtptee");
+  if (!app->rtpTee) {
+    *error = "Encoded RTP tee was not created";
+    stop_pipeline(app);
+    return false;
+  }
+  gst_object_unref(app->rtpTee);
+
+  GstBus* bus = gst_element_get_bus(app->pipeline);
+  app->busWatch = gst_bus_add_watch(bus, bus_watch_cb, app);
+  gst_object_unref(bus);
+  const GstStateChangeReturn state = gst_element_set_state(
+      app->pipeline, GST_STATE_PLAYING);
+  if (state == GST_STATE_CHANGE_FAILURE) {
+    *error = "GStreamer capture pipeline failed to start";
+    stop_pipeline(app);
+    return false;
+  }
+  if (state == GST_STATE_CHANGE_ASYNC) {
+    const GstStateChangeReturn settled = gst_element_get_state(
+        app->pipeline, nullptr, nullptr, 5 * GST_SECOND);
+    if (settled != GST_STATE_CHANGE_SUCCESS &&
+        settled != GST_STATE_CHANGE_NO_PREROLL) {
+      *error = "GStreamer capture pipeline did not reach PLAYING";
+      stop_pipeline(app);
+      return false;
+    }
+  }
+  return true;
+}
+
+void apply_remote_description(App* app, const std::vector<std::string>& fields) {
+  if (fields.size() != 5 || fields[1] != app->sessionId || fields[3] != "answer") return;
+  auto found = app->peers.find(fields[2]);
+  if (found == app->peers.end() || !found->second->webrtc) return;
+
+  GstSDPMessage* sdp = nullptr;
+  if (gst_sdp_message_new(&sdp) != GST_SDP_OK ||
+      gst_sdp_message_parse_buffer(
+          reinterpret_cast<const guint8*>(fields[4].data()), fields[4].size(), sdp) != GST_SDP_OK) {
+    if (sdp) gst_sdp_message_free(sdp);
+    emit_error(app, fields[2], "Could not parse WebRTC answer", false);
+    return;
+  }
+  GstWebRTCSessionDescription* answer = gst_webrtc_session_description_new(
+      GST_WEBRTC_SDP_TYPE_ANSWER, sdp);
+  GstPromise* promise = gst_promise_new();
+  g_signal_emit_by_name(found->second->webrtc, "set-remote-description",
+                        answer, promise);
+  gst_promise_interrupt(promise);
+  gst_promise_unref(promise);
+  gst_webrtc_session_description_free(answer);
+}
+
+void apply_ice_candidate(App* app, const std::vector<std::string>& fields) {
+  if (fields.size() != 8 || fields[1] != app->sessionId) return;
+  auto found = app->peers.find(fields[2]);
+  if (found == app->peers.end() || !found->second->webrtc) return;
+  int mlineIndex = 0;
+  if (!fields[5].empty() && !parse_int(fields[5], 0, 128, &mlineIndex)) return;
+  const gchar* candidate = fields[7] == "1" ? nullptr : fields[3].c_str();
+  g_signal_emit_by_name(found->second->webrtc, "add-ice-candidate",
+                        static_cast<guint>(mlineIndex), candidate);
+}
+
+void handle_start(App* app, const std::vector<std::string>& fields) {
+  if (fields.size() != 14 || app->pipeline || !valid_session_id(fields[1])) return;
+  CaptureConfig config;
+  config.sourceKind = fields[2];
+  config.sourceHandle = fields[3];
+  if (!parse_int(fields[4], -100000, 100000, &config.x) ||
+      !parse_int(fields[5], -100000, 100000, &config.y) ||
+      !parse_int(fields[6], 0, 16384, &config.sourceWidth) ||
+      !parse_int(fields[7], 0, 16384, &config.sourceHeight) ||
+      !parse_int(fields[8], 0, 4320, &config.outputHeight) ||
+      !parse_int(fields[9], 1, 120, &config.frameRate) ||
+      !parse_int(fields[10], 250000, 50000000, &config.bitrate)) {
+    return;
+  }
+  config.icePolicy = fields[11] == "relay" ? "relay" : "all";
+  config.stunUrl = fields[12];
+  config.turnServers = parse_turn_servers(fields[13]);
+  app->sessionId = fields[1];
+  app->config = config;
+  app->starting = true;
+  app->cancelStartup = false;
+
+  std::string error;
+  const bool started = start_pipeline(app, config, &error);
+  app->starting = false;
+  if (app->cancelStartup) {
+    app->stopping = true;
+    stop_pipeline(app);
+    emit_event(app, "STOPPED", {app->sessionId});
+    g_main_loop_quit(app->loop);
+    return;
+  }
+  if (!started) {
+    emit_error(app, "", error, true);
+    return;
+  }
+  emit_event(app, "READY", {app->sessionId});
+}
+
+void handle_command(App* app, const std::string& line) {
+  const auto fields = decode_command_fields(line);
+  if (fields.empty()) return;
+  const std::string& command = fields[0];
+  if (command == "START") {
+    handle_start(app, fields);
+  } else if (command == "ADD_PEER" && fields.size() == 3 &&
+             fields[1] == app->sessionId) {
+    std::string error;
+    if (!add_peer(app, fields[2], &error)) emit_error(app, fields[2], error, false);
+  } else if (command == "REMOVE_PEER" && fields.size() == 3 &&
+             fields[1] == app->sessionId) {
+    remove_peer(app, fields[2]);
+  } else if (command == "REMOTE_DESCRIPTION") {
+    apply_remote_description(app, fields);
+  } else if (command == "ICE") {
+    apply_ice_candidate(app, fields);
+  } else if (command == "STOP" && fields.size() == 2 &&
+              fields[1] == app->sessionId) {
+    if (app->starting) {
+      app->cancelStartup = true;
+#ifndef G_OS_WIN32
+      if (app->portalRequestLoop) g_main_loop_quit(app->portalRequestLoop);
+#endif
+      return;
+    }
+    app->stopping = true;
+    stop_pipeline(app);
+    emit_event(app, "STOPPED", {app->sessionId});
+    g_main_loop_quit(app->loop);
+  }
+}
+
+struct PendingCommand {
+  App* app;
+  std::string line;
+};
+
+gboolean dispatch_command(gpointer data) {
+  std::unique_ptr<PendingCommand> pending(static_cast<PendingCommand*>(data));
+  handle_command(pending->app, pending->line);
+  return G_SOURCE_REMOVE;
+}
+
+gboolean dispatch_eof(gpointer data) {
+  App* app = static_cast<App*>(data);
+  if (!app->stopping) {
+    app->stopping = true;
+    stop_pipeline(app);
+    g_main_loop_quit(app->loop);
+  }
+  return G_SOURCE_REMOVE;
+}
+
+void read_commands(App* app) {
+  std::string line;
+  while (std::getline(std::cin, line)) {
+    auto* pending = new PendingCommand{app, std::move(line)};
+    g_main_context_invoke(nullptr, dispatch_command, pending);
+  }
+  g_main_context_invoke(nullptr, dispatch_eof, app);
+}
+
+int probe() {
+#ifdef G_OS_WIN32
+  const bool capture = factory_exists("d3d11screencapturesrc");
+  const bool encoder = factory_exists("mfh264enc");
+  const char* encoderName = "mfh264enc";
+#else
+  const bool x11Capture = factory_exists("ximagesrc");
+  const bool pipewireCapture = factory_exists("pipewiresrc");
+  const bool capture = x11Capture || pipewireCapture;
+  const bool modernEncoder = factory_exists("vah264enc");
+  const bool legacyEncoder = factory_exists("vaapih264enc");
+  const bool encoder = modernEncoder || legacyEncoder;
+  const char* encoderName = modernEncoder ? "vah264enc" : "vaapih264enc";
+#endif
+  const bool transport = factory_exists("webrtcbin") &&
+      factory_exists("rtph264pay") && factory_exists("h264parse") &&
+      factory_exists("nicesrc") && factory_exists("nicesink") &&
+      factory_exists("dtlsenc") && factory_exists("srtpenc");
+  const bool supported = capture && encoder && transport;
+  std::cout << "{\"protocolVersion\":" << kProtocolVersion
+            << ",\"supported\":" << (supported ? "true" : "false")
+             << ",\"captureBackends\":[";
+#ifdef G_OS_WIN32
+  if (capture) std::cout << "\"d3d11\"";
+#else
+  bool hasBackend = false;
+  if (x11Capture) {
+    std::cout << "\"x11\"";
+    hasBackend = true;
+  }
+  if (pipewireCapture) {
+    if (hasBackend) std::cout << ',';
+    std::cout << "\"pipewire-portal\"";
+  }
+#endif
+  std::cout << "]"
+             << ",\"encoder\":\"" << encoderName << "\""
+             << ",\"codec\":\"H264\""
+             << ",\"components\":{"
+             << "\"capture\":" << (capture ? "true" : "false") << ','
+             << "\"encoder\":" << (encoder ? "true" : "false") << ','
+             << "\"transport\":" << (transport ? "true" : "false") << '}';
+  if (!supported) {
+    std::cout << ",\"reason\":\"gstreamer-plugins-unavailable\"";
+  }
+  std::cout << "}" << std::endl;
+  return supported ? 0 : 2;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  gst_init(&argc, &argv);
+  if (argc == 2 && std::string(argv[1]) == "--probe") return probe();
+
+  App* app = new App();
+  app->loop = g_main_loop_new(nullptr, FALSE);
+  std::thread inputThread(read_commands, app);
+  inputThread.detach();
+  g_main_loop_run(app->loop);
+  stop_pipeline(app);
+  std::_Exit(0);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "haven-desktop",
-  "version": "1.0.0-beta.1",
+  "version": "1.4.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haven-desktop",
-      "version": "1.0.0-beta.1",
+      "version": "1.4.28",
       "hasInstallScript": true,
-      "license": "MIT-NC",
+      "license": "AGPL-3.0",
       "dependencies": {
         "electron-store": "^8.2.0",
+        "electron-updater": "^6.3.9",
         "node-addon-api": "^8.3.0"
       },
       "devDependencies": {
@@ -18,6 +19,9 @@
         "electron": "^33.2.0",
         "electron-builder": "^25.1.8",
         "node-gyp": "^10.3.1"
+      },
+      "optionalDependencies": {
+        "uiohook-napi": "^1.5.4"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -1129,8 +1133,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
@@ -1808,7 +1811,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2176,6 +2178,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2438,7 +2469,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2678,8 +2708,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3037,7 +3066,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3085,7 +3113,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -3105,8 +3132,7 @@
     "node_modules/lazy-val": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
-      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
@@ -3186,12 +3212,25 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -3520,8 +3559,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/negotiator": {
       "version": "0.6.4",
@@ -3583,6 +3621,18 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-gyp/node_modules/@npmcli/fs": {
@@ -4468,7 +4518,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
       "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
-      "dev": true,
       "engines": {
         "node": ">=11.0.0"
       }
@@ -4818,6 +4867,12 @@
         "fs-extra": "^10.0.0"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -4869,6 +4924,20 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uiohook-napi": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/uiohook-napi/-/uiohook-napi-1.5.5.tgz",
+      "integrity": "sha512-oSlTdnECw2GBfsJPTbBQBeE4v/EXP0EZmX6BJq5nzH/JgFaBE8JpFwEA/kLhiEP7HxQw28FViWiYgdIZzWuuJQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -4903,7 +4972,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
   "license": "AGPL-3.0",
   "homepage": "https://ancsemi.github.io/Haven/",
   "scripts": {
+    "test": "node --test test/*.test.js",
     "start": "electron .",
     "dev": "electron . --dev",
-    "build": "npm run build:native && electron-builder",
-    "build:win": "npm run build:native && electron-builder --win",
-    "build:linux": "npm run build:native && electron-builder --linux",
+    "build": "npm run build:native && npm run stage:native-runtime && electron-builder",
+    "build:win": "npm run build:native && npm run stage:native-runtime && electron-builder --win",
+    "build:linux": "npm run build:native && npm run stage:native-runtime && electron-builder --linux",
     "build:native": "node ./node_modules/node-gyp/bin/node-gyp.js rebuild --directory=native",
+    "stage:native-runtime": "node scripts/stage-gstreamer.js",
     "rebuild:electron": "node ./node_modules/@electron/rebuild/lib/cli.js && npm run build:native",
     "postinstall": "node ./node_modules/@electron/rebuild/lib/cli.js || echo electron-rebuild skipped"
   },

--- a/scripts/stage-gstreamer.js
+++ b/scripts/stage-gstreamer.js
@@ -1,0 +1,167 @@
+'use strict';
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const OUTPUT = path.join(ROOT, 'native', 'runtime', 'gstreamer');
+
+function ensureDirectory(directory) {
+  fs.mkdirSync(directory, { recursive: true });
+}
+
+function copy(source, destination) {
+  ensureDirectory(path.dirname(destination));
+  fs.copyFileSync(source, destination);
+  fs.chmodSync(destination, fs.statSync(source).mode);
+}
+
+function listFiles(directory, predicate) {
+  if (!fs.existsSync(directory)) return [];
+  return fs.readdirSync(directory)
+    .map(name => path.join(directory, name))
+    .filter(file => fs.statSync(file).isFile() && predicate(path.basename(file)));
+}
+
+function stageLinux() {
+  const pluginDirectory = process.env.GSTREAMER_PLUGIN_DIR || execFileSync(
+    'pkg-config',
+    ['--variable=pluginsdir', 'gstreamer-1.0'],
+    { encoding: 'utf8' }
+  ).trim();
+  const helper = path.join(ROOT, 'native', 'build', 'Release', 'haven_screen_share');
+  if (!fs.existsSync(helper)) throw new Error('Build haven_screen_share before staging GStreamer');
+
+  const pluginGroups = [
+    ['coreelements'],
+    ['videorate'],
+    ['videoconvertscale'],
+    ['ximagesrc'],
+    ['pipewire'],
+    ['videoparsersbad'],
+    ['rtp.so'],
+    ['rtpmanager'],
+    ['webrtc.so'],
+    ['nice.so'],
+    ['dtls'],
+    ['srtp'],
+  ];
+  const allPlugins = listFiles(pluginDirectory, name => name.endsWith('.so'));
+  const selected = [];
+  for (const alternatives of pluginGroups) {
+    const plugin = allPlugins.find(file => alternatives.some(token => path.basename(file).includes(token)));
+    if (!plugin) throw new Error(`Missing required GStreamer plugin: ${alternatives.join(' or ')}`);
+    selected.push(plugin);
+  }
+  const vaPlugins = allPlugins.filter(file => /libgstva(?:api)?\.so$/.test(path.basename(file)));
+  if (!vaPlugins.length) throw new Error('Missing VA-API GStreamer encoder plugin');
+  selected.push(...vaPlugins);
+
+  const optionalPlugins = ['videotestsrc'];
+  for (const token of optionalPlugins) {
+    const plugin = allPlugins.find(file => path.basename(file).includes(token));
+    if (plugin) selected.push(plugin);
+  }
+
+  const pluginOutput = path.join(OUTPUT, 'plugins');
+  for (const plugin of new Set(selected)) {
+    copy(plugin, path.join(pluginOutput, path.basename(plugin)));
+  }
+
+  const scannerCandidates = [
+    process.env.GSTREAMER_PLUGIN_SCANNER,
+    '/usr/libexec/gstreamer-1.0/gst-plugin-scanner',
+    '/usr/lib/x86_64-linux-gnu/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner',
+    path.resolve(pluginDirectory, '..', 'gstreamer1.0', 'gstreamer-1.0', 'gst-plugin-scanner'),
+  ];
+  const scanner = scannerCandidates.filter(Boolean).find(fs.existsSync);
+  if (!scanner) throw new Error('Could not locate gst-plugin-scanner');
+  const scannerOutput = path.join(OUTPUT, 'libexec', 'gst-plugin-scanner');
+  copy(scanner, scannerOutput);
+
+  const libraryOutput = path.join(OUTPUT, 'lib');
+  const queue = [helper, scanner, ...selected];
+  const visited = new Set();
+  const excluded = /\/(?:ld-linux|libc\.so|libm\.so|libdl\.so|libpthread\.so|librt\.so|libresolv\.so|libgcc_s\.so)/;
+  while (queue.length) {
+    const binary = queue.shift();
+    if (!binary || visited.has(binary)) continue;
+    visited.add(binary);
+    let output;
+    try {
+      output = execFileSync('ldd', [binary], { encoding: 'utf8' });
+    } catch (err) {
+      output = String(err.stdout || '');
+    }
+    const missing = output.split('\n').filter(line => /=>\s+not found\s*$/.test(line));
+    if (missing.length) {
+      throw new Error(`Missing shared libraries for ${binary}: ${missing.join(', ')}`);
+    }
+    for (const line of output.split('\n')) {
+      const match = line.match(/=>\s+(\/[^\s]+)|^\s*(\/[^\s]+)/);
+      const dependency = match && (match[1] || match[2]);
+      if (!dependency || !fs.existsSync(dependency) || excluded.test(dependency)) continue;
+      const destination = path.join(libraryOutput, path.basename(dependency));
+      if (!fs.existsSync(destination)) copy(dependency, destination);
+      queue.push(dependency);
+    }
+  }
+}
+
+function stageWindows() {
+  const root = process.env.GSTREAMER_1_0_ROOT_MSVC_X86_64 ||
+    process.env.GSTREAMER_ROOT_X86_64 ||
+    'C:\\gstreamer\\1.0\\msvc_x86_64';
+  const binDirectory = path.join(root, 'bin');
+  const pluginDirectory = path.join(root, 'lib', 'gstreamer-1.0');
+  if (!fs.existsSync(binDirectory) || !fs.existsSync(pluginDirectory)) {
+    throw new Error(`GStreamer MSVC runtime was not found at ${root}`);
+  }
+
+  const binOutput = path.join(OUTPUT, 'bin');
+  for (const file of listFiles(binDirectory, name => name.toLowerCase().endsWith('.dll'))) {
+    copy(file, path.join(binOutput, path.basename(file)));
+  }
+
+  const pluginTokens = [
+    'coreelements', 'videorate', 'videoconvertscale', 'd3d11',
+    'mediafoundation', 'gstmf', 'videoparsersbad', 'rtp', 'webrtc', 'nice',
+    'dtls', 'srtp',
+  ];
+  const plugins = listFiles(pluginDirectory, name => {
+    const lower = name.toLowerCase();
+    return lower.endsWith('.dll') && pluginTokens.some(token => lower.includes(token));
+  });
+  const requiredPluginGroups = [
+    ['coreelements'], ['videorate'], ['videoconvertscale'], ['d3d11'],
+    ['mediafoundation', 'gstmf'], ['videoparsersbad'], ['rtp'], ['webrtc'],
+    ['nice'], ['dtls'], ['srtp'],
+  ];
+  for (const alternatives of requiredPluginGroups) {
+    const found = plugins.some(file => alternatives.some(token =>
+      path.basename(file).toLowerCase().includes(token)
+    ));
+    if (!found) {
+      throw new Error(`Missing required GStreamer plugin: ${alternatives.join(' or ')}`);
+    }
+  }
+  const pluginOutput = path.join(OUTPUT, 'plugins');
+  for (const plugin of plugins) copy(plugin, path.join(pluginOutput, path.basename(plugin)));
+
+  const scannerCandidates = [
+    path.join(root, 'libexec', 'gstreamer-1.0', 'gst-plugin-scanner.exe'),
+    path.join(binDirectory, 'gst-plugin-scanner.exe'),
+  ];
+  const scanner = scannerCandidates.find(fs.existsSync);
+  if (!scanner) throw new Error('Could not locate gst-plugin-scanner.exe');
+  copy(scanner, path.join(OUTPUT, 'libexec', 'gst-plugin-scanner.exe'));
+}
+
+fs.rmSync(OUTPUT, { recursive: true, force: true });
+ensureDirectory(OUTPUT);
+if (process.platform === 'linux') stageLinux();
+else if (process.platform === 'win32') stageWindows();
+else throw new Error(`GStreamer staging is unsupported on ${process.platform}`);
+
+console.log(`Staged GStreamer runtime in ${OUTPUT}`);

--- a/src/main/app-preload.js
+++ b/src/main/app-preload.js
@@ -550,14 +550,16 @@ ipcRenderer.on('audio:capture-data', (_event, pcmData) => {
 
 // ─── Listen for screen-picker request from main process ──
 ipcRenderer.on('screen:show-picker', (_event, data) => {
-  showScreenPicker(data?.sources || [], data?.audioApps || [], data?.requestId || null);
+  showScreenPicker(data?.sources || [], data?.audioApps || [], data?.requestId || null, {
+    videoOnly: !!data?.videoOnly,
+  });
 });
 
 // ═══════════════════════════════════════════════════════════
 // Screen-Share Picker  (injected as a full-screen overlay)
 // ═══════════════════════════════════════════════════════════
 
-function showScreenPicker(sources, audioApps, requestId) {
+function showScreenPicker(sources, audioApps, requestId, { videoOnly = false } = {}) {
   // Remove stale picker
   document.getElementById('haven-screen-picker')?.remove();
 
@@ -609,7 +611,9 @@ function showScreenPicker(sources, audioApps, requestId) {
 
     <div class="hsp-box">
       <div class="hsp-title">Share Your Screen</div>
-      <div class="hsp-sub">Choose a window or screen — then optionally pick an application whose audio to share.</div>
+      <div class="hsp-sub">${videoOnly
+        ? 'Choose a window or screen for native hardware encoding.'
+        : 'Choose a window or screen — then optionally pick an application whose audio to share.'}</div>
 
       <div class="hsp-scroll">
         <div class="hsp-sec">
@@ -623,7 +627,7 @@ function showScreenPicker(sources, audioApps, requestId) {
         </div>
       </div>
 
-      <div class="hsp-audio">
+      <div class="hsp-audio"${videoOnly ? ' style="display:none"' : ''}>
         <div class="hsp-sec-title">🔊 Application Audio — isolate audio from a specific app</div>
         <div class="hsp-apps" id="hsp-audio-apps"></div>
       </div>
@@ -637,7 +641,7 @@ function showScreenPicker(sources, audioApps, requestId) {
   document.body.appendChild(overlay);
 
   let selSource = null;
-  let selAudioPid = null;
+  let selAudioPid = videoOnly ? 'none' : null;
 
   const screensEl  = document.getElementById('hsp-screens');
   const windowsEl  = document.getElementById('hsp-windows');
@@ -648,10 +652,22 @@ function showScreenPicker(sources, audioApps, requestId) {
   sources.forEach(src => {
     const el = document.createElement('div');
     el.className = 'hsp-src';
-    const preview = src.thumbnail
-      ? `<img src="${src.thumbnail}" alt="">`
-      : `<div class="hsp-thumb-ph">No preview</div>`;
-    el.innerHTML = `${preview}<div class="hsp-src-name" title="${src.name}">${src.name}</div>`;
+    if (src.thumbnail) {
+      const preview = document.createElement('img');
+      preview.src = src.thumbnail;
+      preview.alt = '';
+      el.appendChild(preview);
+    } else {
+      const placeholder = document.createElement('div');
+      placeholder.className = 'hsp-thumb-ph';
+      placeholder.textContent = 'No preview';
+      el.appendChild(placeholder);
+    }
+    const name = document.createElement('div');
+    name.className = 'hsp-src-name';
+    name.textContent = String(src.name || 'Untitled source');
+    name.title = String(src.name || 'Untitled source');
+    el.appendChild(name);
     el.onclick = () => {
       overlay.querySelectorAll('.hsp-src.sel').forEach(s => s.classList.remove('sel'));
       el.classList.add('sel');
@@ -695,9 +711,25 @@ function showScreenPicker(sources, audioApps, requestId) {
       const el = document.createElement('div');
       el.className = 'hsp-app';
       if (a.active === false) el.style.opacity = '0.55';
-      const icon = a.icon ? `<img class="ico" src="${a.icon}" alt="">` : '🔊';
-      const dim  = a.active === false ? ' <span style="color:#888;font-size:11px">(silent)</span>' : '';
-      el.innerHTML = `${icon}<span>${a.name}${dim}</span>`;
+      if (a.icon) {
+        const icon = document.createElement('img');
+        icon.className = 'ico';
+        icon.src = a.icon;
+        icon.alt = '';
+        el.appendChild(icon);
+      } else {
+        el.appendChild(document.createTextNode('🔊'));
+      }
+      const name = document.createElement('span');
+      name.appendChild(document.createTextNode(String(a.name || 'Unknown application')));
+      if (a.active === false) {
+        const silent = document.createElement('span');
+        silent.style.color = '#888';
+        silent.style.fontSize = '11px';
+        silent.textContent = ' (silent)';
+        name.appendChild(silent);
+      }
+      el.appendChild(name);
       el.title = a.active === false
         ? 'This app is currently silent. Capture will start as soon as it produces audio.'
         : a.name;
@@ -724,7 +756,7 @@ function showScreenPicker(sources, audioApps, requestId) {
     let effectiveAudioPid = selAudioPid;
     // Native pipeline applies to per-app PIDs AND to 'system' (which uses
     // WASAPI exclude-mode in main to strip Haven's voice from the share).
-    const wantsNativePipeline = !cancelled && selAudioPid &&
+    const wantsNativePipeline = !videoOnly && !cancelled && selAudioPid &&
                                 selAudioPid !== 'none';
     if (wantsNativePipeline) {
       _capturedAudioPid = selAudioPid;
@@ -1152,6 +1184,22 @@ window.havenDesktop = {
     stopCapture:     ()    => { teardownAudioPipeline(); return ipcRenderer.invoke('audio:stop-capture'); },
     isSupported:     ()    => ipcRenderer.invoke('audio:is-supported'),
     optOutOfDucking: ()    => ipcRenderer.invoke('audio:opt-out-ducking'),
+  },
+
+  nativeScreen: {
+    getCapabilities:      ()     => ipcRenderer.invoke('native-screen:get-capabilities'),
+    start:                options => ipcRenderer.invoke('native-screen:start', options),
+    stop:                 data   => ipcRenderer.invoke('native-screen:stop', data),
+    addPeer:              data   => ipcRenderer.invoke('native-screen:add-peer', data),
+    removePeer:           data   => ipcRenderer.invoke('native-screen:remove-peer', data),
+    setRemoteDescription: data   => ipcRenderer.invoke('native-screen:set-remote-description', data),
+    addIceCandidate:      data   => ipcRenderer.invoke('native-screen:add-ice-candidate', data),
+    onSignal: callback => {
+      if (typeof callback !== 'function') return () => {};
+      const listener = (_event, signal) => callback(signal);
+      ipcRenderer.on('native-screen:signal', listener);
+      return () => ipcRenderer.removeListener('native-screen:signal', listener);
+    },
   },
 
   devices: {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -13,6 +13,7 @@ const os    = require('os');
 const Store = require('electron-store');
 const { ServerManager }      = require('./server-manager');
 const { AudioCaptureManager } = require('./audio-capture');
+const { NativeScreenManager } = require('./native-screen');
 
 // ── Auto-Updater (electron-updater) ───────────────────────
 let autoUpdater;
@@ -134,6 +135,7 @@ let welcomeWindow   = null;
 let tray            = null;
 let serverManager   = null;
 let audioCapture    = null;
+let nativeScreen    = null;
 let serverViews     = new Map();  // serverUrl → BrowserView
 let activeServerUrl = null;
 let primaryServerUrl = null;       // the server the user actually chose to connect to
@@ -288,6 +290,11 @@ app.on('ready', () => {
 app.whenReady().then(async () => {
   serverManager = new ServerManager(store, { showConsole: SHOW_SERVER || IS_DEV });
   audioCapture  = new AudioCaptureManager();
+  nativeScreen  = new NativeScreenManager({
+    selectSource: selectNativeScreenSource,
+    isOwnerActive: owner => owner === getActiveContents(),
+    registryPath: path.join(app.getPath('userData'), 'gstreamer-registry.bin'),
+  });
   badgeIcon     = createBadgeIcon();
 
   // ── Sync start-on-login with OS ──────────────────────
@@ -683,6 +690,7 @@ app.on('before-quit', () => {
   app.isQuitting = true;
   serverManager?.stopServer();
   audioCapture?.cleanup();
+  nativeScreen?.cleanup();
 });
 
 // ═══════════════════════════════════════════════════════════
@@ -1828,6 +1836,128 @@ function createTray() {
 // capture for the selected application.
 // ───────────────────────────────────────────────────────────
 
+async function selectNativeScreenSource(targetContents, capabilities = {}, signal) {
+  if (!targetContents || targetContents.isDestroyed()) return null;
+
+  const wayland = process.platform === 'linux' &&
+    String(process.env.XDG_SESSION_TYPE || '').toLowerCase() === 'wayland';
+  if (process.platform === 'linux' && capabilities.captureBackends?.includes('pipewire-portal') &&
+      (wayland || !capabilities.captureBackends.includes('x11'))) {
+    // The compositor portal owns source selection and grants the PipeWire FD.
+    return { kind: 'linux-pipewire', handle: '' };
+  }
+
+  let sources;
+  try {
+    sources = await desktopCapturer.getSources({
+      types: ['window', 'screen'],
+      thumbnailSize: { width: 0, height: 0 },
+      fetchWindowIcons: false,
+    });
+  } catch (err) {
+    console.warn(`[NativeScreen] source enumeration failed: ${err.message}`);
+    throw err;
+  }
+
+  if (signal?.aborted) return null;
+  const ownerWindow = BrowserWindow.fromWebContents(targetContents) ||
+    targetContents.getOwnerBrowserWindow?.() || mainWindow;
+  let picker;
+  const chosenSource = await new Promise(resolve => {
+    let settled = false;
+    const finish = source => {
+      if (settled) return;
+      settled = true;
+      signal?.removeEventListener('abort', abort);
+      resolve(source);
+    };
+    const abort = () => {
+      try { picker?.closePopup(ownerWindow || undefined); } catch {}
+      finish(null);
+    };
+    const items = sources.map(source => ({
+      label: `${source.id.startsWith('screen:') ? 'Screen' : 'Window'}: ${source.name}`,
+      click: () => finish(source),
+    }));
+    items.push({ type: 'separator' }, { label: 'Cancel', click: () => finish(null) });
+    picker = Menu.buildFromTemplate(items);
+    signal?.addEventListener('abort', abort, { once: true });
+    try {
+      picker.popup({ window: ownerWindow || undefined, callback: () => finish(null) });
+    } catch {
+      finish(null);
+    }
+  });
+  if (!chosenSource) return null;
+  const freshSources = await desktopCapturer.getSources({
+    types: ['window', 'screen'],
+    thumbnailSize: { width: 0, height: 0 },
+    fetchWindowIcons: false,
+  });
+  const selected = freshSources.find(source =>
+    source.id === chosenSource.id && source.name === chosenSource.name
+  );
+  if (!selected) return null;
+
+  const idMatch = /^(screen|window):([^:]+):/.exec(selected.id);
+  if (!idMatch) throw new Error(`Unsupported screen source identifier: ${selected.id}`);
+  const sourceType = idMatch[1];
+  const sourceHandle = idMatch[2];
+
+  if (process.platform === 'win32') {
+    const displays = screen.getAllDisplays();
+    const display = sourceType === 'screen'
+      ? displays.find(item => String(item.id) === String(selected.display_id)) ||
+        displays[Number(sourceHandle)] || displays[0]
+      : null;
+    if (sourceType === 'screen' && !display) return null;
+    const monitorPoint = display ? screen.dipToScreenPoint({
+      x: Math.round(display.bounds.x + display.bounds.width / 2),
+      y: Math.round(display.bounds.y + display.bounds.height / 2),
+    }) : { x: 0, y: 0 };
+    return {
+      kind: sourceType === 'window' ? 'windows-window' : 'windows-monitor',
+      handle: sourceType === 'window'
+        ? sourceHandle
+        : '',
+      x: monitorPoint.x,
+      y: monitorPoint.y,
+      width: display ? Math.round(display.bounds.width * (display.scaleFactor || 1)) : 0,
+      height: display ? Math.round(display.bounds.height * (display.scaleFactor || 1)) : 0,
+    };
+  }
+
+  if (process.platform === 'linux') {
+    if (sourceType === 'window') {
+      return {
+        kind: 'linux-x11-window',
+        handle: sourceHandle,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+      };
+    }
+    const displays = screen.getAllDisplays();
+    const display = displays.find(item => String(item.id) === String(selected.display_id)) ||
+      displays[Number(sourceHandle)] || displays[0];
+    const physicalX = item => Math.round(item.bounds.x * (item.scaleFactor || 1));
+    const physicalY = item => Math.round(item.bounds.y * (item.scaleFactor || 1));
+    const minX = Math.min(...displays.map(physicalX));
+    const minY = Math.min(...displays.map(physicalY));
+    return {
+      kind: 'linux-x11-screen',
+      handle: sourceHandle,
+      x: display ? physicalX(display) - minX : 0,
+      y: display ? physicalY(display) - minY : 0,
+      width: display ? Math.round(display.bounds.width * (display.scaleFactor || 1)) : 0,
+      height: display ? Math.round(display.bounds.height * (display.scaleFactor || 1)) : 0,
+    };
+  }
+
+  throw new Error('Native screen sharing is unavailable on this platform');
+}
+
 function registerScreenShareHandler() {
   // ── Resolve the user's picker selection at attach time ──
   // The desktopCapturer source IDs are not stable: between the moment the
@@ -2159,6 +2289,32 @@ function registerIPC() {
   ipcMain.handle('audio:stop-capture',   () => { try { audioCapture.stopCapture(); } catch {} });
   ipcMain.handle('audio:is-supported',   () => { try { return audioCapture.isSupported(); } catch { return false; } });
   ipcMain.handle('audio:opt-out-ducking', () => audioCapture.optOutOfDucking());
+
+  // ── Native Screen Share ───────────────────────────────
+  const isServerView = sender => Array.from(serverViews.values())
+    .some(view => view.webContents === sender);
+  ipcMain.handle('native-screen:get-capabilities', event => {
+    if (!isServerView(event.sender)) return { supported: false, reason: 'untrusted-view' };
+    return nativeScreen.getCapabilities();
+  });
+  ipcMain.handle('native-screen:start', (event, options) => {
+    if (!isServerView(event.sender)) return { started: false, reason: 'untrusted-view' };
+    if (event.sender !== getActiveContents()) {
+      return { started: false, reason: 'inactive-view' };
+    }
+    return nativeScreen.start(event.sender, options);
+  });
+  ipcMain.handle('native-screen:stop', (event, data) => {
+    return nativeScreen.stop(event.sender, false, data?.sessionId || null);
+  });
+  ipcMain.handle('native-screen:add-peer', (event, data) => nativeScreen.addPeer(event.sender, data));
+  ipcMain.handle('native-screen:remove-peer', (event, data) => nativeScreen.removePeer(event.sender, data));
+  ipcMain.handle('native-screen:set-remote-description', (event, data) => {
+    return nativeScreen.setRemoteDescription(event.sender, data);
+  });
+  ipcMain.handle('native-screen:add-ice-candidate', (event, data) => {
+    return nativeScreen.addIceCandidate(event.sender, data);
+  });
 
   // ── Audio Devices ─────────────────────────────────────
   ipcMain.handle('devices:get-inputs', async () => {

--- a/src/main/native-screen.js
+++ b/src/main/native-screen.js
@@ -1,0 +1,656 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { execFile, spawn } = require('child_process');
+
+const PROTOCOL_VERSION = 2;
+const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{8,64}$/;
+const NEGOTIATION_ID_PATTERN = /^[A-Za-z0-9_-]{8,64}$/;
+const SOURCE_KINDS = new Set([
+  'linux-x11-screen',
+  'linux-x11-window',
+  'linux-pipewire',
+  'windows-monitor',
+  'windows-window',
+  'test',
+]);
+
+function encodeField(value) {
+  return Buffer.from(String(value ?? ''), 'utf8').toString('base64');
+}
+
+function decodeField(value) {
+  return Buffer.from(String(value || ''), 'base64').toString('utf8');
+}
+
+function firstIceServer(iceServers, prefix) {
+  for (const server of Array.isArray(iceServers) ? iceServers : []) {
+    const urls = Array.isArray(server?.urls) ? server.urls : [server?.urls];
+    const url = urls.find(candidate => typeof candidate === 'string' && candidate.startsWith(prefix));
+    if (url) {
+      return {
+        url,
+        username: typeof server.username === 'string' ? server.username : '',
+        credential: typeof server.credential === 'string' ? server.credential : '',
+      };
+    }
+  }
+  return { url: '', username: '', credential: '' };
+}
+
+function turnIceServers(iceServers) {
+  const result = [];
+  for (const server of Array.isArray(iceServers) ? iceServers : []) {
+    const urls = Array.isArray(server?.urls) ? server.urls : [server?.urls];
+    for (const url of urls) {
+      if (typeof url !== 'string' || !/^turns?:/.test(url)) continue;
+      result.push({
+        url,
+        username: typeof server.username === 'string' ? server.username : '',
+        credential: typeof server.credential === 'string' ? server.credential : '',
+      });
+      if (result.length >= 16) return result;
+    }
+  }
+  return result;
+}
+
+function encodeTurnServers(servers) {
+  return servers.map(server => [server.url, server.username, server.credential]
+    .map(encodeField).join(',')).join(';');
+}
+
+class NativeScreenManager {
+  constructor(options = {}) {
+    this._selectSource = options.selectSource;
+    this._spawn = options.spawn || spawn;
+    this._execFile = options.execFile || (options.spawnSync
+      ? (file, args, execOptions, callback) => {
+          const result = options.spawnSync(file, args, execOptions);
+          const error = result.error || (result.status
+            ? Object.assign(new Error(`native helper exited (${result.status})`), {
+                code: result.status,
+              })
+            : null);
+          queueMicrotask(() => callback(error, result.stdout || '', result.stderr || ''));
+        }
+      : execFile);
+    this._existsSync = options.existsSync || fs.existsSync;
+    this._resourcesPath = options.resourcesPath || process.resourcesPath || '';
+    this._projectRoot = options.projectRoot || path.join(__dirname, '..', '..');
+    this._platform = options.platform || process.platform;
+    this._env = options.env || process.env;
+    this._registryPath = options.registryPath || '';
+    this._helperPath = options.helperPath || null;
+    this._isOwnerActive = options.isOwnerActive || (() => true);
+    this._session = null;
+    this._starting = false;
+    this._pendingStart = null;
+    this._capabilities = null;
+    this._probePromise = null;
+  }
+
+  getCapabilities() {
+    if (this._capabilities) return Promise.resolve(this._capabilities);
+    if (this._probePromise) return this._probePromise;
+    this._probePromise = this._probeCapabilities()
+      .then(capabilities => {
+        if (capabilities.supported) this._capabilities = capabilities;
+        return capabilities;
+      })
+      .finally(() => { this._probePromise = null; });
+    return this._probePromise;
+  }
+
+  async _probeCapabilities() {
+    const finish = capabilities => capabilities;
+    if (!['linux', 'win32'].includes(this._platform)) {
+      return finish({ supported: false, reason: 'unsupported-platform' });
+    }
+
+    const helperPath = this._findHelperPath();
+    if (!helperPath) return finish({ supported: false, reason: 'native-helper-unavailable' });
+
+    let result;
+    try {
+      result = await new Promise(resolve => {
+        this._execFile(helperPath, ['--probe'], {
+          encoding: 'utf8',
+          timeout: 5000,
+          windowsHide: true,
+          env: this._helperEnv(),
+        }, (error, stdout, stderr) => {
+          resolve({
+            error: error && typeof error.code !== 'number' ? error : null,
+            status: error && typeof error.code === 'number' ? error.code : 0,
+            stdout,
+            stderr,
+          });
+        });
+      });
+    } catch (err) {
+      return finish({ supported: false, reason: 'native-helper-probe-failed', detail: err.message });
+    }
+
+    if (result.error) {
+      return finish({
+        supported: false,
+        reason: 'native-helper-probe-failed',
+        detail: result.error.message,
+      });
+    }
+
+    let capabilities;
+    try {
+      capabilities = JSON.parse(String(result.stdout || '').trim());
+    } catch {
+      return finish({
+        supported: false,
+        reason: result.status === 0
+          ? 'native-helper-protocol-error'
+          : 'native-helper-probe-failed',
+        detail: String(result.stderr || '').trim() || undefined,
+      });
+    }
+
+    if (!capabilities || typeof capabilities !== 'object' || Array.isArray(capabilities)) {
+      return finish({ supported: false, reason: 'native-helper-protocol-error' });
+    }
+    if (capabilities.protocolVersion !== PROTOCOL_VERSION) {
+      return finish({
+        ...capabilities,
+        supported: false,
+        reason: 'native-helper-protocol-mismatch',
+      });
+    }
+    if (!capabilities.supported) {
+      return finish({
+        ...capabilities,
+        supported: false,
+        reason: capabilities.reason || 'native-helper-unsupported',
+      });
+    }
+    if (result.status !== 0) {
+      return finish({
+        ...capabilities,
+        supported: false,
+        reason: 'native-helper-probe-failed',
+        detail: String(result.stderr || '').trim() || undefined,
+      });
+    }
+
+    const backends = Array.isArray(capabilities.captureBackends)
+      ? capabilities.captureBackends
+      : [];
+    const wayland = this._platform === 'linux' &&
+      String(this._env.XDG_SESSION_TYPE || '').toLowerCase() === 'wayland';
+    if (wayland && !backends.includes('pipewire-portal')) {
+      return finish({ ...capabilities, supported: false, reason: 'wayland-portal-unavailable' });
+    }
+
+    return finish(capabilities);
+  }
+
+  async start(owner, options = {}) {
+    if (!owner || owner.isDestroyed?.()) return { started: false, reason: 'invalid-owner' };
+    if (this._starting) return { started: false, reason: 'native-screen-start-pending' };
+    this._starting = true;
+    options = options && typeof options === 'object' ? options : {};
+    const pending = { owner, controller: new AbortController() };
+    this._pendingStart = pending;
+    const invalidateOwner = () => pending.controller.abort();
+    const invalidateNavigation = (_event, _url, isInPlace, isMainFrame) => {
+      if (!isInPlace && isMainFrame !== false) invalidateOwner();
+    };
+    const ownerListeners = [
+      ['destroyed', invalidateOwner],
+      ['render-process-gone', invalidateOwner],
+      ['did-start-navigation', invalidateNavigation],
+    ];
+    for (const [event, listener] of ownerListeners) owner.on?.(event, listener);
+    try {
+      return await this._start(owner, options, pending.controller);
+    } finally {
+      for (const [event, listener] of ownerListeners) {
+        owner.removeListener?.(event, listener);
+      }
+      if (this._pendingStart === pending) this._pendingStart = null;
+      this._starting = false;
+    }
+  }
+
+  async _start(owner, options, controller) {
+    const { signal } = controller;
+    if (typeof this._selectSource !== 'function') {
+      return { started: false, reason: 'source-selector-unavailable' };
+    }
+
+    const capabilities = await this.getCapabilities();
+    if (signal.aborted) {
+      return { started: false, cancelled: true, reason: 'native-screen-start-cancelled' };
+    }
+    if (!capabilities.supported) return { started: false, reason: capabilities.reason };
+    if (this._session) {
+      if (this._session.owner !== owner) {
+        return { started: false, reason: 'native-screen-owned-by-another-view' };
+      }
+      await this.stop(owner);
+    }
+
+    const source = await this._selectSource(owner, capabilities, signal);
+    if (signal.aborted) {
+      return { started: false, cancelled: true, reason: 'native-screen-start-cancelled' };
+    }
+    if (owner.isDestroyed?.() || !this._isOwnerActive(owner)) {
+      return { started: false, reason: 'inactive-view' };
+    }
+    if (!source) return { started: false, cancelled: true };
+    if (!SOURCE_KINDS.has(source.kind)) return { started: false, reason: 'unsupported-source' };
+
+    const helperPath = this._findHelperPath();
+    if (!helperPath) return { started: false, reason: 'native-helper-unavailable' };
+
+    const sessionId = crypto.randomBytes(15).toString('base64url');
+    let child;
+    try {
+      child = this._spawn(helperPath, [], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+        env: this._helperEnv(),
+      });
+    } catch (err) {
+      return { started: false, reason: 'native-helper-spawn-failed', detail: err.message };
+    }
+    const session = {
+      id: sessionId,
+      owner,
+      child,
+      peers: new Set(),
+      peerNegotiations: new Map(),
+      stdoutBuffer: '',
+      stopping: false,
+      readyResolve: null,
+      readyReject: null,
+      stoppedResolve: null,
+      stopPromise: null,
+    };
+    this._session = session;
+    this._wireProcess(session);
+    this._wireOwner(session);
+
+    let startupTimer;
+    try {
+      const ready = new Promise((resolve, reject) => {
+        session.readyResolve = resolve;
+        session.readyReject = reject;
+      });
+      ready.catch(() => {});
+      const stun = firstIceServer(options.iceServers, 'stun:');
+      const turnServers = turnIceServers(options.iceServers);
+      this._send(session, 'START', [
+        sessionId,
+        source.kind,
+        source.handle || '',
+        Number.isFinite(source.x) ? source.x : 0,
+        Number.isFinite(source.y) ? source.y : 0,
+        Number.isFinite(source.width) ? source.width : 0,
+        Number.isFinite(source.height) ? source.height : 0,
+        Math.max(0, Math.min(4320, Number(options.resolution) || 0)),
+        Math.max(1, Math.min(120, Number(options.frameRate) || 30)),
+        Math.max(250000, Math.min(50000000, Number(options.bitrate) || 8000000)),
+        options.iceTransportPolicy === 'relay' ? 'relay' : 'all',
+        stun.url,
+        encodeTurnServers(turnServers),
+      ]);
+      await Promise.race([
+        ready,
+        new Promise((_, reject) => {
+          const timeout = source.kind === 'linux-pipewire' ? 125000 : 10000;
+          startupTimer = setTimeout(() => reject(new Error('native helper startup timed out')), timeout);
+        }),
+      ]);
+      if (this._session !== session) throw new Error('native helper exited during startup');
+      return { started: true, sessionId };
+    } catch (err) {
+      if (this._session === session) {
+        await this.stop(owner, true);
+      } else {
+        try { session.child.kill(); } catch {}
+      }
+      return {
+        started: false,
+        reason: 'native-helper-start-failed',
+        detail: err.message,
+        cancelled: /cancelled/i.test(String(err.message || '')),
+      };
+    } finally {
+      if (startupTimer) clearTimeout(startupTimer);
+    }
+  }
+
+  async stop(owner, force = false, expectedSessionId = null) {
+    const session = this._session;
+    if (!session) {
+      if (expectedSessionId) return false;
+      const pending = this._pendingStart;
+      if (pending && (force || pending.owner === owner)) pending.controller.abort();
+      return true;
+    }
+    this._assertOwner(owner, session, force);
+    if (expectedSessionId && expectedSessionId !== session.id) return false;
+    if (session.stopPromise) return session.stopPromise;
+
+    session.stopping = true;
+    session.readyReject?.(new Error('Native screen startup cancelled'));
+    session.readyResolve = null;
+    session.readyReject = null;
+    session.stopPromise = (async () => {
+      const stopped = new Promise(resolve => { session.stoppedResolve = resolve; });
+      let sent = false;
+      try {
+        this._send(session, 'STOP', [session.id]);
+        sent = true;
+      } catch {}
+      let stopTimer;
+      if (sent) {
+        await Promise.race([
+          stopped,
+          new Promise(resolve => { stopTimer = setTimeout(resolve, 1500); }),
+        ]);
+      }
+      if (stopTimer) clearTimeout(stopTimer);
+      if (this._session === session) {
+        this._detachOwner(session);
+        try { session.child.kill(); } catch {}
+        this._session = null;
+      }
+      return true;
+    })();
+    return session.stopPromise;
+  }
+
+  async addPeer(owner, data = {}) {
+    const session = this._requireSession(owner, data);
+    const peerId = this._validPeerId(data.peerId);
+    if (session.peers.has(peerId)) return true;
+    session.peers.add(peerId);
+    this._send(session, 'ADD_PEER', [session.id, peerId]);
+    return true;
+  }
+
+  async removePeer(owner, data = {}) {
+    const session = this._requireSession(owner, data);
+    const peerId = this._validPeerId(data.peerId);
+    session.peers.delete(peerId);
+    session.peerNegotiations.delete(peerId);
+    this._send(session, 'REMOVE_PEER', [session.id, peerId]);
+    return true;
+  }
+
+  async setRemoteDescription(owner, data = {}) {
+    const session = this._requireSession(owner, data);
+    const peerId = this._validPeerId(data.peerId);
+    this._requireNegotiation(session, peerId, data.negotiationId);
+    const description = data.description;
+    if (!description || description.type !== 'answer' || typeof description.sdp !== 'string' ||
+        description.sdp.length > 16384) {
+      throw new Error('Invalid native screen answer');
+    }
+    this._send(session, 'REMOTE_DESCRIPTION', [session.id, peerId, 'answer', description.sdp]);
+    return true;
+  }
+
+  async addIceCandidate(owner, data = {}) {
+    const session = this._requireSession(owner, data);
+    const peerId = this._validPeerId(data.peerId);
+    this._requireNegotiation(session, peerId, data.negotiationId);
+    const candidate = data.candidate;
+    if (candidate == null) {
+      this._send(session, 'ICE', [session.id, peerId, '', '', '', '', '1']);
+      return true;
+    }
+    if (typeof candidate !== 'object' || typeof candidate.candidate !== 'string' ||
+        candidate.candidate.length > 2048) {
+      throw new Error('Invalid native screen ICE candidate');
+    }
+    this._send(session, 'ICE', [
+      session.id,
+      peerId,
+      candidate.candidate,
+      candidate.sdpMid || '',
+      Number.isInteger(candidate.sdpMLineIndex) ? candidate.sdpMLineIndex : '',
+      candidate.usernameFragment || '',
+      '0',
+    ]);
+    return true;
+  }
+
+  cleanup() {
+    this._pendingStart?.controller.abort();
+    if (!this._session) return;
+    const session = this._session;
+    session.readyReject?.(new Error('Native screen owner was destroyed'));
+    session.readyResolve = null;
+    session.readyReject = null;
+    this._detachOwner(session);
+    try { session.child.kill(); } catch {}
+    this._session = null;
+  }
+
+  _findHelperPath() {
+    const binary = this._platform === 'win32' ? 'haven_screen_share.exe' : 'haven_screen_share';
+    const candidates = [
+      this._helperPath,
+      this._resourcesPath && path.join(this._resourcesPath, 'native', binary),
+      path.join(this._projectRoot, 'native', 'build', 'Release', binary),
+    ].filter(Boolean);
+    return candidates.find(candidate => this._existsSync(candidate)) || null;
+  }
+
+  _helperEnv() {
+    const env = {
+      ...this._env,
+      GST_XINITTHREADS: '1',
+      HAVEN_NATIVE_SCREEN_PROTOCOL: String(PROTOCOL_VERSION),
+    };
+    const runtime = this._resourcesPath && path.join(this._resourcesPath, 'native', 'gstreamer');
+    if (!runtime || !this._existsSync(runtime)) return env;
+
+    const plugins = path.join(runtime, 'plugins');
+    const scanner = path.join(
+      runtime,
+      'libexec',
+      this._platform === 'win32' ? 'gst-plugin-scanner.exe' : 'gst-plugin-scanner'
+    );
+    env.GST_PLUGIN_PATH_1_0 = plugins;
+    env.GST_PLUGIN_SYSTEM_PATH_1_0 = plugins;
+    env.GST_PLUGIN_SCANNER_1_0 = scanner;
+    if (this._registryPath) env.GST_REGISTRY_1_0 = this._registryPath;
+    if (this._platform === 'win32') {
+      env.PATH = `${path.join(runtime, 'bin')}${path.delimiter}${env.PATH || ''}`;
+    } else {
+      env.LD_LIBRARY_PATH = `${path.join(runtime, 'lib')}${path.delimiter}${env.LD_LIBRARY_PATH || ''}`;
+    }
+    return env;
+  }
+
+  _wireProcess(session) {
+    session.child.stdout.setEncoding('utf8');
+    session.child.stderr.setEncoding('utf8');
+    session.child.stdout.on('data', chunk => {
+      session.stdoutBuffer += chunk;
+      let newline;
+      while ((newline = session.stdoutBuffer.indexOf('\n')) !== -1) {
+        const line = session.stdoutBuffer.slice(0, newline).replace(/\r$/, '');
+        session.stdoutBuffer = session.stdoutBuffer.slice(newline + 1);
+        if (line) this._handleLine(session, line);
+      }
+    });
+    session.child.stderr.on('data', chunk => {
+      const message = String(chunk || '').trim();
+      if (message) console.warn('[NativeScreen helper]', message);
+    });
+    session.child.on('error', err => this._handleProcessEnd(session, null, null, err));
+    session.child.on('exit', (code, signal) => this._handleProcessEnd(session, code, signal));
+  }
+
+  _wireOwner(session) {
+    const endSession = () => {
+      if (this._session === session) this.cleanup();
+    };
+    const navigate = (_event, _url, isInPlace, isMainFrame) => {
+      if (!isInPlace && isMainFrame !== false) endSession();
+    };
+    session.ownerListeners = [
+      ['destroyed', endSession],
+      ['render-process-gone', endSession],
+      ['did-start-navigation', navigate],
+    ];
+    for (const [event, listener] of session.ownerListeners) {
+      session.owner.on?.(event, listener);
+    }
+  }
+
+  _detachOwner(session) {
+    for (const [event, listener] of session.ownerListeners || []) {
+      session.owner.removeListener?.(event, listener);
+    }
+    session.ownerListeners = [];
+  }
+
+  _handleLine(session, line) {
+    if (this._session !== session) return;
+    const fields = line.split('\t');
+    const event = fields.shift();
+    const values = fields.map(decodeField);
+    if (values[0] !== session.id) return;
+
+    if (event === 'READY') {
+      session.readyResolve?.();
+      session.readyResolve = null;
+      session.readyReject = null;
+      return;
+    }
+    if (event === 'STOPPED') {
+      session.stoppedResolve?.();
+      return;
+    }
+    if (event === 'OFFER') {
+      const [, peerId, sdp] = values;
+      if (!session.peers.has(peerId)) return;
+      const negotiationId = crypto.randomBytes(15).toString('base64url');
+      session.peerNegotiations.set(peerId, negotiationId);
+      this._emitSignal(session, {
+        type: 'offer',
+        sessionId: session.id,
+        negotiationId,
+        peerId: Number(peerId),
+        description: { type: 'offer', sdp },
+      });
+      return;
+    }
+    if (event === 'ICE') {
+      const [, peerId, candidate, sdpMid, sdpMLineIndex, usernameFragment, end] = values;
+      const negotiationId = session.peerNegotiations.get(peerId);
+      if (!negotiationId) return;
+      this._emitSignal(session, {
+        type: 'ice-candidate',
+        sessionId: session.id,
+        negotiationId,
+        peerId: Number(peerId),
+        candidate: end === '1' ? null : {
+          candidate,
+          sdpMid: sdpMid || null,
+          sdpMLineIndex: sdpMLineIndex === '' ? null : Number(sdpMLineIndex),
+          usernameFragment: usernameFragment || null,
+        },
+      });
+      return;
+    }
+    if (event === 'ERROR') {
+      const [, peerId, message, fatal] = values;
+      const failedDuringStartup = fatal === '1' && !!session.readyReject;
+      if (failedDuringStartup) {
+        session.readyReject(new Error(message || 'Native screen helper failed to start'));
+        session.readyResolve = null;
+        session.readyReject = null;
+      }
+      this._emitSignal(session, {
+        type: 'error',
+        sessionId: session.id,
+        peerId: peerId ? Number(peerId) : null,
+        message,
+        fatal: fatal === '1',
+      });
+      if (fatal === '1' && !failedDuringStartup && this._session === session) {
+        this._detachOwner(session);
+        this._session = null;
+        try { session.child.kill(); } catch {}
+      }
+    }
+  }
+
+  _handleProcessEnd(session, code, signal, error = null) {
+    if (this._session !== session) return;
+    session.readyReject?.(error || new Error(`native helper exited (${code ?? signal ?? 'unknown'})`));
+    session.stoppedResolve?.();
+    this._detachOwner(session);
+    this._session = null;
+    if (!session.stopping) {
+      this._emitSignal(session, {
+        type: 'error',
+        sessionId: session.id,
+        peerId: null,
+        message: error?.message || `Native screen helper exited unexpectedly (${code ?? signal ?? 'unknown'})`,
+        fatal: true,
+      });
+    }
+  }
+
+  _send(session, command, fields) {
+    if (!session.child.stdin.writable) throw new Error('Native screen helper is not writable');
+    session.child.stdin.write([command, ...fields.map(encodeField)].join('\t') + '\n');
+  }
+
+  _emitSignal(session, signal) {
+    if (!session.owner || session.owner.isDestroyed?.()) return;
+    try { session.owner.send('native-screen:signal', signal); } catch {}
+  }
+
+  _assertOwner(owner, session, force = false) {
+    if (!force && owner !== session.owner) throw new Error('Native screen session belongs to another view');
+  }
+
+  _requireSession(owner, data) {
+    const session = this._session;
+    if (!session) throw new Error('No active native screen session');
+    this._assertOwner(owner, session);
+    if (!SESSION_ID_PATTERN.test(String(data.sessionId || '')) || data.sessionId !== session.id) {
+      throw new Error('Stale native screen session');
+    }
+    return session;
+  }
+
+  _validPeerId(peerId) {
+    const value = Number(peerId);
+    if (!Number.isSafeInteger(value) || value <= 0) throw new Error('Invalid native screen peer');
+    return String(value);
+  }
+
+  _requireNegotiation(session, peerId, negotiationId) {
+    if (!NEGOTIATION_ID_PATTERN.test(String(negotiationId || '')) ||
+        session.peerNegotiations.get(peerId) !== negotiationId) {
+      throw new Error('Stale native screen negotiation');
+    }
+  }
+}
+
+module.exports = {
+  NativeScreenManager,
+  NEGOTIATION_ID_PATTERN,
+  PROTOCOL_VERSION,
+  decodeField,
+  encodeField,
+};

--- a/test/native-screen.test.js
+++ b/test/native-screen.test.js
@@ -1,0 +1,465 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { PassThrough } = require('node:stream');
+const test = require('node:test');
+
+const {
+  NativeScreenManager,
+  decodeField,
+  encodeField,
+} = require('../src/main/native-screen');
+
+function createOwner() {
+  const owner = new EventEmitter();
+  owner.destroyed = false;
+  owner.signals = [];
+  owner.isDestroyed = () => owner.destroyed;
+  owner.send = (event, payload) => owner.signals.push({ event, payload });
+  return owner;
+}
+
+function createFakeHelper() {
+  const child = new EventEmitter();
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.commands = [];
+  child.killed = false;
+  child.kill = () => {
+    child.killed = true;
+    child.emit('exit', 0, null);
+  };
+  let buffer = '';
+  child.stdin.on('data', chunk => {
+    buffer += chunk.toString('utf8');
+    let newline;
+    while ((newline = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      const [command, ...fields] = line.split('\t');
+      const values = fields.map(decodeField);
+      child.commands.push({ command, values });
+      if (command === 'START') {
+        child.stdout.write(`READY\t${encodeField(values[0])}\n`);
+      } else if (command === 'STOP') {
+        child.stdout.write(`STOPPED\t${encodeField(values[0])}\n`);
+      }
+    }
+  });
+  return child;
+}
+
+function createManager(overrides = {}) {
+  const helper = overrides.helper || createFakeHelper();
+  const capabilities = {
+    protocolVersion: 2,
+    supported: true,
+    captureBackends: ['x11'],
+    encoder: 'vah264enc',
+  };
+  const manager = new NativeScreenManager({
+    platform: 'linux',
+    env: { XDG_SESSION_TYPE: 'x11' },
+    helperPath: '/fake/haven_screen_share',
+    existsSync: () => true,
+    spawnSync: () => ({ status: 0, stdout: JSON.stringify(capabilities), stderr: '' }),
+    spawn: () => helper,
+    selectSource: async () => ({
+      kind: 'linux-x11-screen',
+      handle: '0',
+      x: 0,
+      y: 0,
+      width: 1920,
+      height: 1080,
+    }),
+    ...overrides,
+  });
+  return { manager, helper };
+}
+
+test('starts the helper and forwards native offers to the owning renderer', async () => {
+  const owner = createOwner();
+  const { manager, helper } = createManager();
+
+  const result = await manager.start(owner, {
+    resolution: 1080,
+    frameRate: 60,
+    bitrate: 8_000_000,
+    iceServers: [
+      { urls: 'stun:stun.example.test:3478' },
+      {
+        urls: [
+          'turn:turn.example.test:3478?transport=udp',
+          'turn:turn.example.test:3478?transport=tcp',
+          'turns:turn.example.test:5349',
+        ],
+        username: 'haven',
+        credential: 'secret',
+      },
+    ],
+  });
+
+  assert.equal(result.started, true);
+  assert.match(result.sessionId, /^[A-Za-z0-9_-]{8,64}$/);
+  assert.equal(helper.commands[0].command, 'START');
+  assert.equal(helper.commands[0].values[0], result.sessionId);
+  assert.equal(helper.commands[0].values[1], 'linux-x11-screen');
+  assert.equal(helper.commands[0].values[8], '60');
+  const turnUrls = helper.commands[0].values[12].split(';').map(record =>
+    decodeField(record.split(',')[0])
+  );
+  assert.deepEqual(turnUrls, [
+    'turn:turn.example.test:3478?transport=udp',
+    'turn:turn.example.test:3478?transport=tcp',
+    'turns:turn.example.test:5349',
+  ]);
+
+  await manager.addPeer(owner, { sessionId: result.sessionId, peerId: 7 });
+  helper.stdout.write([
+    'OFFER',
+    encodeField(result.sessionId),
+    encodeField('7'),
+    encodeField('v=0\r\n'),
+  ].join('\t') + '\n');
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.equal(owner.signals.length, 1);
+  assert.match(owner.signals[0].payload.negotiationId, /^[A-Za-z0-9_-]{8,64}$/);
+  assert.deepEqual(owner.signals, [{
+    event: 'native-screen:signal',
+    payload: {
+      type: 'offer',
+      sessionId: result.sessionId,
+      negotiationId: owner.signals[0].payload.negotiationId,
+      peerId: 7,
+      description: { type: 'offer', sdp: 'v=0\r\n' },
+    },
+  }]);
+  await manager.stop(owner);
+  assert.equal(helper.killed, true);
+});
+
+test('rejects commands from another renderer and stale sessions', async () => {
+  const owner = createOwner();
+  const other = createOwner();
+  const { manager } = createManager();
+  const result = await manager.start(owner, {});
+
+  await assert.rejects(
+    manager.addPeer(other, { sessionId: result.sessionId, peerId: 7 }),
+    /another view/
+  );
+  await assert.rejects(
+    manager.addPeer(owner, { sessionId: 'native-session-old1', peerId: 7 }),
+    /Stale native screen session/
+  );
+  await manager.stop(owner);
+});
+
+test('uses the PipeWire portal backend on Wayland', async () => {
+  const helper = createFakeHelper();
+  const owner = createOwner();
+  const { manager } = createManager({
+    helper,
+    env: { XDG_SESSION_TYPE: 'wayland' },
+    spawnSync: () => ({
+      status: 0,
+      stdout: JSON.stringify({
+        protocolVersion: 2,
+        supported: true,
+        captureBackends: ['x11', 'pipewire-portal'],
+        encoder: 'vah264enc',
+      }),
+      stderr: '',
+    }),
+    selectSource: async () => ({ kind: 'linux-pipewire', handle: '' }),
+  });
+
+  assert.equal((await manager.getCapabilities()).supported, true);
+  const result = await manager.start(owner, {});
+  assert.equal(result.started, true);
+  assert.equal(helper.commands[0].values[1], 'linux-pipewire');
+  await manager.stop(owner);
+});
+
+test('rejects startup immediately when the helper reports a fatal error', async () => {
+  const helper = createFakeHelper();
+  helper.stdin.removeAllListeners('data');
+  helper.stdin.on('data', chunk => {
+    const [command, session] = chunk.toString('utf8').trim().split('\t');
+    if (command === 'START') {
+      helper.stdout.write([
+        'ERROR', session, encodeField(''), encodeField('portal failed'), encodeField('1'),
+      ].join('\t') + '\n');
+    } else if (command === 'STOP') {
+      helper.stdout.write(`STOPPED\t${session}\n`);
+    }
+  });
+  const owner = createOwner();
+  const { manager } = createManager({ helper });
+  const result = await manager.start(owner, {});
+  assert.equal(result.started, false);
+  assert.equal(result.reason, 'native-helper-start-failed');
+  assert.equal(result.detail, 'portal failed');
+});
+
+test('rejects incompatible helper protocols even when the helper says supported', async () => {
+  const { manager } = createManager({
+    spawnSync: () => ({
+      status: 0,
+      stdout: JSON.stringify({
+        protocolVersion: 3,
+        supported: true,
+        captureBackends: ['x11'],
+      }),
+      stderr: '',
+    }),
+  });
+  assert.deepEqual(await manager.getCapabilities(), {
+    protocolVersion: 3,
+    supported: false,
+    captureBackends: ['x11'],
+    reason: 'native-helper-protocol-mismatch',
+  });
+});
+
+test('preserves an unsupported probe reason when the helper exits nonzero', async () => {
+  const { manager } = createManager({
+    spawnSync: () => ({
+      status: 2,
+      stdout: JSON.stringify({
+        protocolVersion: 2,
+        supported: false,
+        captureBackends: ['x11'],
+        reason: 'gstreamer-plugins-unavailable',
+      }),
+      stderr: '',
+    }),
+  });
+  assert.equal((await manager.getCapabilities()).reason, 'gstreamer-plugins-unavailable');
+});
+
+test('does not cache transient helper probe failures', async () => {
+  let probes = 0;
+  const { manager } = createManager({
+    spawnSync: () => {
+      probes++;
+      if (probes === 1) return { status: 1, stdout: '', stderr: 'busy' };
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          protocolVersion: 2,
+          supported: true,
+          captureBackends: ['x11'],
+          encoder: 'vah264enc',
+        }),
+        stderr: '',
+      };
+    },
+  });
+
+  assert.equal((await manager.getCapabilities()).supported, false);
+  assert.equal((await manager.getCapabilities()).supported, true);
+  assert.equal(probes, 2);
+});
+
+test('serializes starts and does not replace another renderer session', async () => {
+  let selectSource;
+  const pendingSource = new Promise(resolve => { selectSource = resolve; });
+  const owner = createOwner();
+  const other = createOwner();
+  const { manager } = createManager({ selectSource: () => pendingSource });
+
+  const firstStart = manager.start(owner, {});
+  assert.deepEqual(await manager.start(other, {}), {
+    started: false,
+    reason: 'native-screen-start-pending',
+  });
+  selectSource({ kind: 'linux-x11-screen', handle: '0' });
+  const firstResult = await firstStart;
+  assert.equal(firstResult.started, true);
+  assert.deepEqual(await manager.start(other, {}), {
+    started: false,
+    reason: 'native-screen-owned-by-another-view',
+  });
+  await manager.stop(owner);
+});
+
+test('kills the helper when its renderer reloads or reports a fatal runtime error', async () => {
+  const owner = createOwner();
+  let setup = createManager();
+  let result = await setup.manager.start(owner, {});
+  owner.emit('did-start-navigation', {}, 'https://haven.test', false, true);
+  assert.equal(setup.helper.killed, true);
+  assert.equal(setup.manager._session, null);
+
+  setup = createManager();
+  result = await setup.manager.start(owner, {});
+  setup.helper.stdout.write([
+    'ERROR',
+    encodeField(result.sessionId),
+    encodeField(''),
+    encodeField('pipeline failed'),
+    encodeField('1'),
+  ].join('\t') + '\n');
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(setup.helper.killed, true);
+  assert.equal(setup.manager._session, null);
+  assert.equal(owner.signals.at(-1).payload.fatal, true);
+});
+
+test('does not spawn the helper if its renderer navigates while the picker is open', async () => {
+  let spawnCalls = 0;
+  const owner = createOwner();
+  const { manager } = createManager({
+    selectSource: async () => ({ kind: 'linux-x11-screen', handle: '0' }),
+    spawn: () => {
+      spawnCalls++;
+      return createFakeHelper();
+    },
+  });
+
+  const pending = manager.start(owner, {});
+  owner.emit('did-start-navigation', {}, 'https://haven.test/other', false, true);
+
+  assert.deepEqual(await pending, {
+    started: false,
+    cancelled: true,
+    reason: 'native-screen-start-cancelled',
+  });
+  assert.equal(spawnCalls, 0);
+});
+
+test('stop aborts a pending picker before a helper session exists', async () => {
+  let spawnCalls = 0;
+  const owner = createOwner();
+  const { manager } = createManager({
+    selectSource: (_owner, _capabilities, signal) => new Promise(resolve => {
+      signal.addEventListener('abort', () => resolve(null), { once: true });
+    }),
+    spawn: () => {
+      spawnCalls++;
+      return createFakeHelper();
+    },
+  });
+
+  const pending = manager.start(owner, {});
+  assert.equal(await manager.stop(owner), true);
+  assert.deepEqual(await pending, {
+    started: false,
+    cancelled: true,
+    reason: 'native-screen-start-cancelled',
+  });
+  assert.equal(spawnCalls, 0);
+});
+
+test('owner navigation aborts the pending native picker immediately', async () => {
+  const owner = createOwner();
+  const { manager } = createManager({
+    selectSource: (_owner, _capabilities, signal) => new Promise(resolve => {
+      signal.addEventListener('abort', () => resolve(null), { once: true });
+    }),
+  });
+
+  const pending = manager.start(owner, {});
+  owner.emit('did-start-navigation', {}, 'https://haven.test/other', false, true);
+
+  assert.deepEqual(await pending, {
+    started: false,
+    cancelled: true,
+    reason: 'native-screen-start-cancelled',
+  });
+});
+
+test('a stale stop cannot abort a newer pending picker', async () => {
+  let aborts = 0;
+  const owner = createOwner();
+  const { manager } = createManager({
+    selectSource: (_owner, _capabilities, signal) => new Promise(resolve => {
+      signal.addEventListener('abort', () => {
+        aborts++;
+        resolve(null);
+      }, { once: true });
+    }),
+  });
+
+  const pending = manager.start(owner, {});
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(await manager.stop(owner, false, 'native-session-old1'), false);
+  assert.equal(aborts, 0);
+  assert.equal(await manager.stop(owner), true);
+  await pending;
+  assert.equal(aborts, 1);
+});
+
+test('rejects answers and ICE from a replaced peer negotiation', async () => {
+  const owner = createOwner();
+  const { manager, helper } = createManager();
+  const result = await manager.start(owner, {});
+  await manager.addPeer(owner, { sessionId: result.sessionId, peerId: 7 });
+  helper.stdout.write([
+    'OFFER', encodeField(result.sessionId), encodeField('7'), encodeField('v=0\r\n'),
+  ].join('\t') + '\n');
+  await new Promise(resolve => setImmediate(resolve));
+  const negotiationId = owner.signals.at(-1).payload.negotiationId;
+
+  await assert.rejects(manager.setRemoteDescription(owner, {
+    sessionId: result.sessionId,
+    negotiationId: 'stale-negotiation',
+    peerId: 7,
+    description: { type: 'answer', sdp: 'v=0\r\n' },
+  }), /Stale native screen negotiation/);
+  await manager.addIceCandidate(owner, {
+    sessionId: result.sessionId,
+    negotiationId,
+    peerId: 7,
+    candidate: null,
+  });
+  assert.equal(helper.commands.at(-1).command, 'ICE');
+  await manager.stop(owner);
+});
+
+test('drops an offer that arrives after its peer was removed', async () => {
+  const owner = createOwner();
+  const { manager, helper } = createManager();
+  const result = await manager.start(owner, {});
+  await manager.addPeer(owner, { sessionId: result.sessionId, peerId: 7 });
+  await manager.removePeer(owner, { sessionId: result.sessionId, peerId: 7 });
+  helper.stdout.write([
+    'OFFER', encodeField(result.sessionId), encodeField('7'), encodeField('v=0\r\n'),
+  ].join('\t') + '\n');
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.equal(owner.signals.length, 0);
+  await manager.stop(owner);
+});
+
+test('a stale session-specific stop does not kill a newer helper', async () => {
+  const owner = createOwner();
+  const { manager, helper } = createManager();
+  const result = await manager.start(owner, {});
+
+  assert.equal(await manager.stop(owner, false, 'native-session-old1'), false);
+  assert.equal(helper.killed, false);
+  assert.equal(await manager.stop(owner, false, result.sessionId), true);
+  assert.equal(helper.killed, true);
+});
+
+test('normalizes null options and tears down after a synchronous START failure', async () => {
+  const owner = createOwner();
+  let setup = createManager();
+  let result = await setup.manager.start(owner, null);
+  assert.equal(result.started, true);
+  await setup.manager.stop(owner);
+
+  const helper = createFakeHelper();
+  Object.defineProperty(helper.stdin, 'writable', { value: false });
+  setup = createManager({ helper });
+  result = await setup.manager.start(owner, {});
+  assert.equal(result.started, false);
+  assert.equal(result.reason, 'native-helper-start-failed');
+  assert.equal(helper.killed, true);
+  assert.equal(setup.manager._session, null);
+});


### PR DESCRIPTION
## Summary

- Add native H.264 screen sharing through a standalone GStreamer helper.
- Support X11 and PipeWire portal capture on Linux.
- Support D3D11 capture and Media Foundation H.264 encoding on Windows.
- Encode once per sharing session and distribute RTP through one WebRTC peer per viewer.
- Add session and negotiation identifiers to reject stale answers and ICE candidates.
- Use trusted main-process source selection without exposing screen thumbnails to the renderer.
- Package the required GStreamer runtime and validate capture/transport capabilities in CI.
- Fall back to Chromium screen sharing when native capture is unavailable or fails before announcement.
- Keep the initial native implementation video-only.

## Testing

- `npm test`: 17 tests passed.
- `node --check` passed for all changed JavaScript files.
- C++ syntax validation passed with `-Wall -Wextra -Werror`.
- Native helper build and staged-runtime probe passed with protocol version 2.
- Portal startup cancellation and helper teardown passed.
- Electron E2E decoded H.264 frames at 1280x720.
- AppImage and Debian packages were built and probed successfully.
- Packaged helper hashes match the validated build.

## Notes

- Local Windows hardware validation was not available; the Windows build and staging path is covered by GitHub Actions.
- Interactive X11 and Wayland source selection still require validation on real desktop sessions.

## Paired PR

Server signaling implementation: https://github.com/ancsemi/Haven/pull/5535