### PR TITLE
Push-to-talk hold on any key; screen picker shares our own window, always scrolls, follows the theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Haven Desktop Changelog
 
+## Unreleased
+
+### Fixed
+- **Push-to-talk "Hold" spam-toggled mute while the key was held (Windows, NumLock).** Any ordinary key went through Electron's `globalShortcut`, which has no key-up and re-fires on OS auto-repeat, and the hold branch sent the toggle event anyway. Single keys uiohook knows (NumLock, F13, Space, letters, digits, numpad) now go through uiohook like the bare modifiers, with real press and release and auto-repeat suppressed. Combos that still land on `globalShortcut` emulate hold: talk on the first press, release 350 ms after the repeats stop. Reported by Dispencer2.
+- **Haven Desktop's own window can be screen-shared.** `desktopCapturer` never lists windows of the calling process, so the app's window is added from `getMediaSourceId()` with a live thumbnail. Useful when walking someone through the app. Expect the hall-of-mirrors preview; that is inherent. Reported by Dispencer2.
+- **The screen-share picker sometimes had no scroll bar for Application Windows.** The scroll pane was `flex: 1` next to non-shrinking siblings inside a `max-height` box, so a tall audio-app row could squeeze it to nothing; closing and reopening happened to land on a shorter row. The box now has a definite height, the list keeps a minimum height, the audio row scrolls on its own past 30vh, and the scrollbar is visible. Reported by Dispencer2.
+- **The screen-share picker follows the app theme.** It is an overlay inside the Haven page, but every colour was hardcoded to an old palette. It now uses the theme variables (`--bg-card`, `--accent`, `--text-primary`, ...) with the old values as fallbacks, so it matches Settings and switches live with the theme. Its Cancel button no longer inherits the server picker's full-width rule. Reported by Dispencer2.
+
 ## v1.4.30
 
 ### Added

--- a/src/main/app-preload.js
+++ b/src/main/app-preload.js
@@ -794,46 +794,60 @@ function showScreenPicker(sources, audioApps, requestId) {
   overlay.lang = i18nState.locale;
   overlay.innerHTML = `
     <style>
+      /* The picker is an overlay inside the Haven page, so the app's theme
+         variables are in scope. Fallbacks keep the login and splash pages,
+         which carry no theme, looking the way they did. */
       #haven-screen-picker {
         position:fixed;inset:0;background:rgba(0,0,0,.88);z-index:999999;
         display:flex;align-items:center;justify-content:center;
-        font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+        font-family:var(--font-main,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif);
       }
-      .hsp-box{background:#1a1a2e;border-radius:14px;padding:28px;max-width:820px;width:92%;
-        max-height:82vh;display:flex;flex-direction:column;border:1px solid rgba(107,79,219,.3);
+      /* height (not max-height) makes the flex budget definite on the first
+         layout, min-height on the list keeps the window grid from being
+         squeezed out by a tall audio-app row, and the audio row scrolls on
+         its own past 30vh. Together they end the "no scrollbar sometimes". */
+      .hsp-box{background:var(--bg-card,#1a1a2e);border-radius:var(--radius,14px);padding:28px;max-width:820px;width:92%;
+        height:82vh;max-height:82vh;display:flex;flex-direction:column;border:1px solid var(--border,rgba(107,79,219,.3));
         box-shadow:0 20px 60px rgba(0,0,0,.5);}
-      .hsp-title{color:#e0e0e0;font-size:20px;font-weight:700;margin-bottom:2px;flex-shrink:0}
-      .hsp-sub{color:#888;font-size:13px;margin-bottom:14px;flex-shrink:0}
-      .hsp-scroll{flex:1;overflow-y:auto;padding-right:4px;margin-right:-4px;min-height:0}
+      .hsp-title{color:var(--text-primary,#e0e0e0);font-size:20px;font-weight:700;margin-bottom:2px;flex-shrink:0}
+      .hsp-sub{color:var(--text-secondary,#888);font-size:13px;margin-bottom:14px;flex-shrink:0}
+      .hsp-scroll{flex:1 1 auto;overflow-y:auto;padding-right:6px;margin-right:-6px;min-height:9rem;
+        scrollbar-width:auto;scrollbar-color:var(--accent,#6b4fdb) transparent}
+      .hsp-scroll::-webkit-scrollbar{width:10px}
+      .hsp-scroll::-webkit-scrollbar-thumb{background:var(--accent,#6b4fdb);border-radius:5px;opacity:.75}
       .hsp-sec{margin-bottom:14px}
-      .hsp-sec-title{color:#aaa;font-size:11px;text-transform:uppercase;letter-spacing:1.2px;
+      .hsp-sec-title{color:var(--text-muted,#aaa);font-size:11px;text-transform:uppercase;letter-spacing:1.2px;
         margin-bottom:8px;font-weight:700}
       .hsp-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(175px,1fr));gap:10px}
-      .hsp-src{background:#16213e;border-radius:8px;padding:8px;cursor:pointer;
+      .hsp-src{background:var(--bg-tertiary,#16213e);border-radius:8px;padding:8px;cursor:pointer;
         border:2px solid transparent;transition:border-color .2s,transform .15s}
-      .hsp-src:hover{border-color:rgba(107,79,219,.5);transform:translateY(-1px)}
-      .hsp-src.sel{border-color:#6b4fdb}
+      .hsp-src:hover{border-color:var(--accent-glow,rgba(107,79,219,.5));transform:translateY(-1px)}
+      .hsp-src.sel{border-color:var(--accent,#6b4fdb)}
       .hsp-src img{width:100%;border-radius:4px;margin-bottom:6px;aspect-ratio:16/9;
-        object-fit:cover;background:#0d0d1a}
+        object-fit:cover;background:var(--bg-input,#0d0d1a)}
       .hsp-src .hsp-thumb-ph{width:100%;border-radius:4px;margin-bottom:6px;aspect-ratio:16/9;
-        background:linear-gradient(135deg,#0d0d1a,#1a1a2e);display:flex;align-items:center;
-        justify-content:center;color:#777;font-size:11px;letter-spacing:.3px}
-      .hsp-src-name{color:#ccc;font-size:12px;text-align:center;white-space:nowrap;
+        background:linear-gradient(135deg,var(--bg-input,#0d0d1a),var(--bg-primary,#1a1a2e));display:flex;align-items:center;
+        justify-content:center;color:var(--text-muted,#777);font-size:11px;letter-spacing:.3px}
+      .hsp-src-name{color:var(--text-primary,#ccc);font-size:12px;text-align:center;white-space:nowrap;
         overflow:hidden;text-overflow:ellipsis}
-      .hsp-audio{padding-top:14px;border-top:1px solid #2a2a4a;flex-shrink:0;margin-top:10px}
+      .hsp-audio{padding-top:14px;border-top:1px solid var(--border,#2a2a4a);flex:0 1 auto;margin-top:10px;
+        max-height:30vh;overflow-y:auto}
       .hsp-apps{display:flex;flex-wrap:wrap;gap:8px}
-      .hsp-app{background:#16213e;border-radius:6px;padding:8px 14px;cursor:pointer;
+      .hsp-app{background:var(--bg-tertiary,#16213e);border-radius:6px;padding:8px 14px;cursor:pointer;
         border:2px solid transparent;transition:border-color .2s;display:flex;
-        align-items:center;gap:8px;color:#ccc;font-size:13px}
-      .hsp-app:hover{border-color:rgba(107,79,219,.5)}
-      .hsp-app.sel{border-color:#6b4fdb}
+        align-items:center;gap:8px;color:var(--text-primary,#ccc);font-size:13px}
+      .hsp-app:hover{border-color:var(--accent-glow,rgba(107,79,219,.5))}
+      .hsp-app.sel{border-color:var(--accent,#6b4fdb)}
       .hsp-app .ico{width:20px;height:20px}
       .hsp-btns{display:flex;justify-content:flex-end;gap:10px;margin-top:16px;flex-shrink:0}
       .hsp-btn{padding:8px 22px;border-radius:6px;border:none;font-size:14px;cursor:pointer;font-weight:600}
-      .hsp-cancel{background:#333;color:#ccc}.hsp-cancel:hover{background:#444}
-      .hsp-share{background:#6b4fdb;color:#fff}.hsp-share:hover{background:#7b5fe9}
+      /* Scoped: the server picker's global .hsp-cancel rule (display:block;
+         width:100%) otherwise stretches this Cancel across the row. */
+      #haven-screen-picker .hsp-cancel{display:inline-block;width:auto;margin-top:0;background:var(--bg-hover,#333);color:var(--text-secondary,#ccc)}
+      #haven-screen-picker .hsp-cancel:hover{background:var(--bg-active,#444)}
+      .hsp-share{background:var(--accent,#6b4fdb);color:var(--accent-text,#fff)}.hsp-share:hover{background:var(--accent-hover,#7b5fe9)}
       .hsp-share:disabled{opacity:.45;cursor:not-allowed}
-      .hsp-none{color:#666;font-size:12px;font-style:italic;padding:8px}
+      .hsp-none{color:var(--text-muted,#666);font-size:12px;font-style:italic;padding:8px}
     </style>
 
     <div class="hsp-box">

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -562,8 +562,33 @@ function _accelToUiohookKeycode(accel) {
     'Super':            K.MetaR,
   };
   const primary = map[accel];
-  if (primary == null) return null;
+  if (primary == null) {
+    const generic = _genericUiohookKeycode(K, accel);
+    return generic == null ? null : [generic];
+  }
   return [primary, altMap[accel]].filter(v => v != null);
+}
+
+// Electron accelerator name -> uiohook UiohookKey name for a single key.
+// Hold-mode push-to-talk needs key-up, which globalShortcut never delivers,
+// so a plain key like NumLock has to go through uiohook like the bare
+// modifiers do. Combos (Ctrl+F5) stay on globalShortcut.
+function _genericUiohookKeycode(K, accel) {
+  if (!accel || accel.includes('+')) return null;
+  const alias = {
+    Numlock: 'NumLock', Capslock: 'CapsLock', Scrolllock: 'ScrollLock', Esc: 'Escape',
+    Return: 'Enter', Up: 'ArrowUp', Down: 'ArrowDown', Left: 'ArrowLeft', Right: 'ArrowRight',
+    Plus: 'Equal', numadd: 'NumpadAdd', numsub: 'NumpadSubtract', nummult: 'NumpadMultiply',
+    numdiv: 'NumpadDivide', numdec: 'NumpadDecimal', ';': 'Semicolon', '`': 'Backquote',
+    '-': 'Minus', '=': 'Equal', '[': 'BracketLeft', ']': 'BracketRight', '\\': 'Backslash',
+    ',': 'Comma', '.': 'Period', '/': 'Slash', "'": 'Quote', ' ': 'Space',
+  };
+  let name = alias[accel] || accel;
+  const num = /^num(\d)$/i.exec(name);
+  if (num) name = `Numpad${num[1]}`;
+  if (/^[a-z]$/.test(name)) name = name.toUpperCase();
+  const code = K[name];
+  return typeof code === 'number' ? code : null;
 }
 
 function _accelToMouseButton(accel) {
@@ -573,10 +598,14 @@ function _accelToMouseButton(accel) {
   return parseInt(m[1], 10);
 }
 
-function _isUiohookAccel(accel) {
+let _gsPttTimer = null;
+
+function _isUiohookAccel(accel, holdMode = false) {
   if (!accel) return false;
   if (/^Mouse\d+$/i.test(accel)) return true;
   if (['Shift', 'Alt', 'Control', 'Ctrl', 'CommandOrControl', 'Meta', 'Cmd', 'Super'].includes(accel)) return true;
+  // Hold needs key-up. Any single key uiohook knows goes through it.
+  if (holdMode && !accel.includes('+') && tryLoadUiohook() && _accelToUiohookKeycode(accel)) return true;
   return false;
 }
 
@@ -634,7 +663,7 @@ function _ensureUiohookStarted() {
   try {
     u.uIOhook.start();
     _uiohookStarted = true;
-    console.log('[Shortcuts] uiohook-napi started — bare modifiers + Mouse4/5 active');
+    console.log('[Shortcuts] uiohook-napi started — bare modifiers, hold-mode keys and Mouse4/5 active');
   } catch (err) {
     console.warn('[Shortcuts] uiohook-napi failed to start:', err.message);
     const hint = _uiohookInstallHint();
@@ -657,9 +686,11 @@ function _stopUiohookIfIdle() {
 
 function unregisterVoiceShortcuts() {
   const cfg = store.get('desktopShortcuts') || {};
+  const pttHold = cfg.pttMode !== 'toggle';
   ['mute', 'deafen', 'ptt'].forEach(k => {
-    try { if (cfg[k] && !_isUiohookAccel(cfg[k])) globalShortcut.unregister(cfg[k]); } catch {}
+    try { if (cfg[k] && !_isUiohookAccel(cfg[k], k === 'ptt' && pttHold)) globalShortcut.unregister(cfg[k]); } catch {}
   });
+  if (_gsPttTimer) { clearTimeout(_gsPttTimer); _gsPttTimer = null; }
   _uiohookKeyBindings.clear();
   _uiohookMouseBindings.clear();
   _uiohookDownState.clear();
@@ -682,7 +713,7 @@ function registerVoiceShortcuts() {
   for (const b of bindings) {
     if (!b.accel) continue;
 
-    if (_isUiohookAccel(b.accel)) {
+    if (_isUiohookAccel(b.accel, b.mode === 'hold')) {
       needUiohook = true;
       const mouseBtn = _accelToMouseButton(b.accel);
       if (mouseBtn != null) {
@@ -704,17 +735,29 @@ function registerVoiceShortcuts() {
       continue;
     }
 
-    // Ordinary accelerator → Electron globalShortcut.
-    // Toggle-only — Electron globalShortcut doesn't expose key-up,
-    // so even if PTT is in hold mode here we degrade to toggle for
-    // keyboard combos (the recorder UI labels this trade-off in the
-    // toast it shows on registration failure).
+    // Ordinary accelerator (a combo, or a key uiohook could not map) →
+    // Electron globalShortcut. It has no key-up and re-fires on OS
+    // auto-repeat, so a hold-mode PTT used to toggle mute on every repeat
+    // while the key was held (Dispencer2, NumLock on Windows). Hold is
+    // emulated instead: talk on the first press, release 350 ms after the
+    // repeats stop.
     try {
       globalShortcut.register(b.accel, () => {
-        const channel = b.event === 'voice:ptt'
-          ? (b.mode === 'hold' ? 'voice:ptt-toggle' : 'voice:ptt-toggle')
-          : b.event;
-        safeSend(getActiveContents(), channel);
+        if (b.event === 'voice:ptt' && b.mode === 'hold') {
+          const stateKey = 'g:voice:ptt';
+          if (!_uiohookDownState.has(stateKey)) {
+            _uiohookDownState.add(stateKey);
+            safeSend(getActiveContents(), 'voice:ptt-down');
+          }
+          if (_gsPttTimer) clearTimeout(_gsPttTimer);
+          _gsPttTimer = setTimeout(() => {
+            _gsPttTimer = null;
+            _uiohookDownState.delete(stateKey);
+            safeSend(getActiveContents(), 'voice:ptt-up');
+          }, 350);
+          return;
+        }
+        safeSend(getActiveContents(), b.event === 'voice:ptt' ? 'voice:ptt-toggle' : b.event);
       });
     } catch (e) {
       console.warn(`[Shortcuts] Failed to register ${b.accel}:`, e.message);
@@ -2012,7 +2055,14 @@ function registerScreenShareHandler() {
   // Re-enumerate, then try ID match, then by name + display_id, then any
   // screen on the same display, then the first screen — only fail if there
   // is literally nothing to share.
+  // desktopCapturer never lists windows of the calling process (Chromium's
+  // enumerate_current_process_windows is off), so Haven's own window is
+  // added by hand from getMediaSourceId(). Handy when walking someone
+  // through the app. Its id is accepted verbatim here.
+  let selfWindowSourceId = null;
+
   async function resolveSelectedSource(originalSources, requestedId) {
+    if (requestedId && requestedId === selfWindowSourceId) return { id: requestedId, name: 'Haven Desktop' };
     const direct = originalSources.find(s => s.id === requestedId);
     if (direct) return direct;
 
@@ -2094,6 +2144,17 @@ function registerScreenShareHandler() {
         appIcon:    s.appIcon ? s.appIcon.toDataURL() : null,
         display_id: s.display_id,
       }));
+      try {
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          selfWindowSourceId = mainWindow.getMediaSourceId();
+          let selfThumb = null;
+          try {
+            const img = await mainWindow.capturePage();
+            if (img && !img.isEmpty()) selfThumb = img.resize({ width: 320 }).toDataURL();
+          } catch {}
+          sourceData.push({ id: selfWindowSourceId, name: 'Haven Desktop', thumbnail: selfThumb, appIcon: null, display_id: '' });
+        }
+      } catch (err) { console.warn('[ScreenShare] self-window source unavailable:', err.message); }
       console.log(`[ScreenShare] source enumeration complete: ${sourceData.length} source(s)`);
 
       const requestFrame = request?.frame;


### PR DESCRIPTION
Four Windows reports from Dispencer2, all in the desktop shell.

## Push-to-talk "Hold" spam-toggles

Any ordinary key (NumLock in the report) went through Electron's `globalShortcut`, which has no key-up and re-fires on OS auto-repeat, and the hold branch in `registerVoiceShortcuts` sent `voice:ptt-toggle` in both modes (`main.js`, the identical ternary). A held key flipped mute on every repeat.

- `_genericUiohookKeycode` maps a single key to a uiohook keycode (NumLock, F13, Space, letters, digits, numpad, common punctuation; combos and mouse names return null). Checked against `uiohook-napi`'s table: NumLock 69, F13 91, Space 57, `a` 30, `num0` 82, `Ctrl+F5` null.
- `_isUiohookAccel(accel, holdMode)` routes hold-mode single keys through uiohook, which already delivers real press and release with auto-repeat suppressed. `unregisterVoiceShortcuts` classifies the same way.
- Combos that still land on `globalShortcut` emulate hold: `voice:ptt-down` on the first press, `voice:ptt-up` 350 ms after the repeats stop.

## Screen picker

- **Own window.** `desktopCapturer` never lists windows of the calling process (Chromium's `enumerate_current_process_windows` is off), so there was no filter to relax. The main window is added from `getMediaSourceId()` with a `capturePage` thumbnail and accepted verbatim by `resolveSelectedSource`. Hall-of-mirrors preview is inherent.
- **Missing scroll bar.** `.hsp-scroll` was `flex: 1` next to non-shrinking siblings inside a `max-height` box, so a tall audio-app row could squeeze it to zero; reopening happened to land on a shorter row. The box now has a definite height, the list `min-height: 9rem`, the audio row scrolls on its own past 30vh, and the scrollbar is 10 px in the accent colour instead of Haven's near-invisible 6 px global bar.
- **Theme.** The picker is an overlay inside the Haven page, so the theme variables are in scope, but every colour was hardcoded to an old palette. It now uses `--bg-card`, `--accent`, `--text-primary` and friends with the old values as fallbacks, so it matches Settings and switches live. Cancel is scoped away from the server picker's global `.hsp-cancel { display:block; width:100% }` rule.

`node --check` on both files; there is no test runner in this repo. CHANGELOG has an Unreleased section with the four entries.