### PR TITLE
Paint the Electron window from the page palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+- **The native window follows the page palette.** Matrix, Braid, Compact and
+  the other themes update the Electron chrome background from `--bg-primary`
+  and `--accent`, so a layout overlay no longer leaves a leftover strip of
+  the previous color.
+
 ### Fixed
 - **The screen share picker sometimes had no scroll bar for application windows.** The list was `flex: 1` beside siblings that never shrink inside a `max-height` box, so a tall audio-app row could squeeze it to nothing. The box has a definite height now, the list keeps a minimum height, the audio row scrolls on its own past 30vh, and the scrollbar is visible. Its Cancel button no longer inherits the server picker's full-width rule. Reported by Dispencer2.
 - **Push to talk in hold mode no longer spam-toggles when the input hook is unavailable.** A key that still goes through Electron's shortcut API re-fires on OS auto-repeat, and each repeat flipped mute. Hold is emulated there instead: talk on the first press, release 350 ms after the repeats stop. Reported by Dispencer2.

--- a/src/main/app-preload.js
+++ b/src/main/app-preload.js
@@ -249,6 +249,50 @@ if (document.documentElement) {
     document.documentElement.setAttribute('data-desktop-app', '1');
   }, { once: true });
 }
+
+// Paint the native window from the page palette so Matrix, Braid, Compact
+// and the rest match the chrome, not only the webview.
+let lastTheme = '';
+function syncTheme() {
+  try {
+    const root = document.documentElement;
+    let theme = root.getAttribute('data-theme') || '';
+    const saved = localStorage.getItem('haven-theme') || localStorage.getItem('haven_theme') || '';
+    if (saved.startsWith('file:')) theme = saved.slice(5).replace(/\.css$/i, '');
+    const cs = getComputedStyle(root);
+    const bg = (cs.getPropertyValue('--bg-primary') || '').trim();
+    const accent = (cs.getPropertyValue('--accent') || '').trim();
+    const key = theme + '|' + bg + '|' + accent;
+    if (key === lastTheme) return;
+    lastTheme = key;
+    ipcRenderer.send('theme:colors', { theme, bg, accent });
+  } catch {}
+}
+function watchTheme() {
+  const root = document.documentElement;
+  if (!root) return false;
+  new MutationObserver(syncTheme).observe(root, { attributes: true, attributeFilter: ['data-theme', 'class', 'style'] });
+  syncTheme();
+  return true;
+}
+if (!watchTheme()) window.addEventListener('DOMContentLoaded', watchTheme, { once: true });
+window.addEventListener('load', () => { syncTheme(); setTimeout(syncTheme, 1500); });
+window.addEventListener('storage', syncTheme);
+
+function injectBraidDesktopCss() {
+  if (document.getElementById('haven-desktop-braid-gap')) return;
+  const el = document.createElement('style');
+  el.id = 'haven-desktop-braid-gap';
+  el.textContent = 'html[data-braid-layout="1"][data-desktop-app]{--thread-footer-offset:0px}'
+    + 'html[data-braid-layout="1"][data-desktop-app] .status-bar,'
+    + 'html[data-braid-layout="1"][data-desktop-app] #status-bar{display:none!important;height:0!important;min-height:0!important;padding:0!important;border:0!important;overflow:hidden!important}'
+    + 'html[data-braid-layout="1"].braid-status-open[data-desktop-app] .status-bar,'
+    + 'html[data-braid-layout="1"].braid-status-open[data-desktop-app] #status-bar{display:flex!important;height:auto!important;min-height:1.75rem!important;padding:.3125rem 1rem!important;overflow:visible!important}'
+    + 'html[data-braid-layout="1"] #app-body{flex:1 1 auto!important;height:auto!important;min-height:0}';
+  (document.head || document.documentElement).appendChild(el);
+}
+if (document.head) injectBraidDesktopCss();
+else window.addEventListener('DOMContentLoaded', injectBraidDesktopCss, { once: true });
 // ═══════════════════════════════════════════════════════════
 // JavaScript Dialog Overrides for BrowserView (issue #6)
 //

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -884,7 +884,7 @@ function createWelcomeWindow() {
     minWidth: 620, minHeight: 480,
     resizable: false,
     frame: false,
-    backgroundColor: '#0d0d1a',
+    backgroundColor: store.get('themeColors.bg') || '#0d0d1a',
     icon: ICON_PATH,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
@@ -911,7 +911,7 @@ function createAppWindow(serverUrl) {
       minWidth: 800, minHeight: 600,
       frame: true,
       autoHideMenuBar: !!store.get('hideMenuBar'),
-      backgroundColor: '#0d0d1a',
+      backgroundColor: store.get('themeColors.bg') || '#0d0d1a',
       icon: ICON_PATH,
       show: false,
       // The BrowserView per-server already disables backgroundThrottling, but
@@ -2414,7 +2414,31 @@ function registerScreenShareHandler() {
 // IPC Handlers
 // ═══════════════════════════════════════════════════════════
 
+function cssColorToHex(s) {
+  if (!s || typeof s !== 'string') return null;
+  const v = s.trim();
+  if (/^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(v)) {
+    const h = v.slice(1);
+    if (h.length === 3 || h.length === 4) return `#${[...h.slice(0, 3)].map((c) => c + c).join('')}`;
+    return `#${h.slice(0, 6)}`;
+  }
+  const m = v.match(/rgba?\(\s*([\d.]+)\s*[, ]+\s*([\d.]+)\s*[, ]+\s*([\d.]+)/i);
+  if (!m) return null;
+  const hex = (n) => Math.round(Number(n)).toString(16).padStart(2, '0');
+  return `#${hex(m[1])}${hex(m[2])}${hex(m[3])}`;
+}
+
+function applyWindowTheme({ bg, accent } = {}) {
+  const color = cssColorToHex(bg) || store.get('themeColors.bg') || '#0d0d1a';
+  store.set('themeColors', { bg: color, accent: cssColorToHex(accent) || store.get('themeColors.accent') || '#7c5cfc' });
+  for (const win of [mainWindow, welcomeWindow]) {
+    if (win && !win.isDestroyed()) win.setBackgroundColor(color);
+  }
+}
+
 function registerIPC() {
+
+  ipcMain.on('theme:colors', (_e, payload) => applyWindowTheme(payload || {}));
 
   // ── Internationalization ──────────────────────────────
   ipcMain.on('i18n:get-state-sync', (event) => {


### PR DESCRIPTION
## Summary
- The app preload reports `--bg-primary` and `--accent` to the main process so the native window matches Matrix, Braid, Compact, and the other palettes.
- Braid no longer leaves a leftover status-bar gap in the desktop shell.

Pairs with Amnibro/Haven `fix/theme-palette-vs-layout` so layout overlays keep the picker colors on desktop too.

## Test plan
- [ ] Join a server, pick Matrix. Window chrome / letterbox matches Matrix, not leftover Braid mint.
- [ ] Pick Braid or Compact as the theme. Window background follows those tokens.
- [ ] Theme → Layout Braid on with Matrix selected. Chrome stays Matrix; no bottom gap.
- [ ] Welcome window uses the last stored palette on next launch.

Made with [Cursor](https://cursor.com)