### PR TITLE
Open a native save dialog when Haven asks to save an image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Added
+- **Save Image uses a native save dialog.** Right-click → Save Image on a
+  photo asks where to put the file. Chromium's `<a download>` does nothing
+  for a lot of proxied http(s) images; the page hands us the bytes instead.
 - **Check for Updates in the Help menu and on the tray icon.** The app only ever checked quietly at start-up, so there was no way to ask. The new entry checks on demand and says when you are already on the latest version. (Haven #5627)
 
 ### Fixed

--- a/src/main/app-preload.js
+++ b/src/main/app-preload.js
@@ -1480,6 +1480,11 @@ window.havenDesktop = {
    *  Same gesture-bypass rationale as clipboardWriteImage. */
   clipboardWriteText: (text) => ipcRenderer.invoke('clipboard:write-text', text),
 
+  /** Native save dialog for images. WebView/Chromium often ignores <a download>
+   *  on http(s) media. Haven passes base64 bytes + a filename. */
+  saveImage: ({ bytes, filename } = {}) =>
+    ipcRenderer.invoke('dialog:save-image', { payload: bytes || '', filename }),
+
   /** Access the Desktop-level server history (persists across all servers) */
   getServerHistory: () => ipcRenderer.invoke('server-history:get'),
   addServerHistory: (url, name) => ipcRenderer.invoke('server-history:add', url, name),

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -2784,6 +2784,31 @@ function registerIPC() {
     }
   });
 
+  // WebView download= is ignored for many http(s) image URLs. Haven calls
+  // havenDesktop.saveImage with base64 bytes so we can show a real save dialog.
+  ipcMain.handle('dialog:save-image', async (e, { payload, filename } = {}) => {
+    try {
+      if (!payload || typeof payload !== 'string') return { ok: false, reason: 'no-payload' };
+      const raw = payload.includes(',') ? payload.slice(payload.lastIndexOf(',') + 1) : payload;
+      const buf = Buffer.from(String(raw).replace(/\s+/g, ''), 'base64');
+      if (!buf.length) return { ok: false, reason: 'empty-image' };
+      const leaf = String(filename || 'haven-image.png').replace(/\\/g, '/').split('/').pop() || 'haven-image.png';
+      const name = leaf.replace(/[^A-Za-z0-9._-]/g, '') || 'haven-image.png';
+      const wc = e && e.sender;
+      const win = (wc && !wc.isDestroyed() && BrowserWindow.fromWebContents(wc)) || mainWindow;
+      const picked = await dialog.showSaveDialog(win && !win.isDestroyed() ? win : undefined, {
+        title: 'Save image',
+        defaultPath: name,
+        filters: [{ name: 'Image', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp'] }],
+      });
+      if (picked.canceled || !picked.filePath) return { ok: false, cancelled: true };
+      fs.writeFileSync(picked.filePath, buf);
+      return { ok: true, path: picked.filePath };
+    } catch (err) {
+      return { ok: false, reason: String(err && err.message || err) };
+    }
+  });
+
   // ── Desktop App Preferences ───────────────────────────
   ipcMain.handle('desktop:get-prefs', () => ({
     startOnLogin:     !!store.get('startOnLogin'),


### PR DESCRIPTION
## Summary
- `havenDesktop.saveImage({ bytes, filename })` opens the OS save dialog and writes the image bytes.
- Chromium often ignores `<a download>` on proxied http(s) photos. Haven already hands the desktop the bytes; Electron now has the same hook Tauri does.

Forum feed and the gallery size sliders live in the server: https://github.com/ancsemi/Haven/pull/5630

## Test plan
- [ ] On a Haven server that calls `havenDesktop.saveImage` (local 3847 has this), right-click an image → Save Image. A native save dialog should appear and the file should write.
- [ ] Cancel the dialog: no file, no crash.
- [ ] Copy Image still works.

Made with [Cursor](https://cursor.com)